### PR TITLE
Firebase Auth: Add createUserWithEmailAndPassword.

### DIFF
--- a/firebase-auth/src/androidMain/kotlin/dev/gitlive/firebase/auth/auth.kt
+++ b/firebase-auth/src/androidMain/kotlin/dev/gitlive/firebase/auth/auth.kt
@@ -24,6 +24,9 @@ actual class FirebaseAuth internal constructor(val android: com.google.firebase.
     actual suspend fun signInWithEmailAndPassword(email: String, password: String) =
         AuthResult(android.signInWithEmailAndPassword(email, password).await())
 
+    actual suspend fun createUserWithEmailAndPassword(email: String, password: String) =
+        AuthResult(android.createUserWithEmailAndPassword(email, password).await())
+
     actual suspend fun signInWithCustomToken(token: String) =
         AuthResult(android.signInWithCustomToken(token).await())
 

--- a/firebase-auth/src/commonMain/kotlin/dev/gitlive/firebase/auth/auth.kt
+++ b/firebase-auth/src/commonMain/kotlin/dev/gitlive/firebase/auth/auth.kt
@@ -18,6 +18,7 @@ expect class FirebaseAuth {
     val currentUser: FirebaseUser?
     val authStateChanged: Flow<FirebaseUser?>
     suspend fun signInWithEmailAndPassword(email: String, password: String): AuthResult
+    suspend fun createUserWithEmailAndPassword(email: String, password: String): AuthResult
     suspend fun signInWithCustomToken(token: String): AuthResult
     suspend fun signInAnonymously(): AuthResult
     suspend fun signOut()

--- a/firebase-auth/src/commonTest/kotlin/dev/gitlive/firebase/auth/auth.kt
+++ b/firebase-auth/src/commonTest/kotlin/dev/gitlive/firebase/auth/auth.kt
@@ -46,5 +46,7 @@ class FirebaseAuthTest {
 
         val signInResult = Firebase.auth.signInWithEmailAndPassword(email, "test123")
         assertEquals(createResult.user?.uid, signInResult.user?.uid)
+
+        signInResult.user!!.delete()
     }
 }

--- a/firebase-auth/src/commonTest/kotlin/dev/gitlive/firebase/auth/auth.kt
+++ b/firebase-auth/src/commonTest/kotlin/dev/gitlive/firebase/auth/auth.kt
@@ -7,10 +7,11 @@ package dev.gitlive.firebase.auth
 import dev.gitlive.firebase.Firebase
 import dev.gitlive.firebase.FirebaseOptions
 import dev.gitlive.firebase.initialize
-import kotlinx.coroutines.GlobalScope
+import kotlin.random.Random
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 
 expect val context: Any
 expect fun runTest(test: suspend () -> Unit)
@@ -35,5 +36,15 @@ class FirebaseAuthTest {
     fun testSignInWithUsernameAndPassword() = runTest {
         val result = Firebase.auth.signInWithEmailAndPassword("test@test.com", "test123")
         assertEquals("mn8kgIFnxLO7il8GpTa5g0ObP6I2", result.user!!.uid)
+    }
+
+    @Test
+    fun testCreateUserWithEmailAndPassword() = runTest {
+        val email = "test+${Random.nextInt(100000)}@test.com"
+        val createResult = Firebase.auth.createUserWithEmailAndPassword(email, "test123")
+        assertNotEquals(null, createResult.user?.uid)
+
+        val signInResult = Firebase.auth.signInWithEmailAndPassword(email, "test123")
+        assertEquals(createResult.user?.uid, signInResult.user?.uid)
     }
 }

--- a/firebase-auth/src/commonTest/kotlin/dev/gitlive/firebase/auth/auth.kt
+++ b/firebase-auth/src/commonTest/kotlin/dev/gitlive/firebase/auth/auth.kt
@@ -4,9 +4,7 @@
 
 package dev.gitlive.firebase.auth
 
-import dev.gitlive.firebase.Firebase
-import dev.gitlive.firebase.FirebaseOptions
-import dev.gitlive.firebase.initialize
+import dev.gitlive.firebase.*
 import kotlin.random.Random
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -17,19 +15,20 @@ expect val context: Any
 expect fun runTest(test: suspend () -> Unit)
 
 class FirebaseAuthTest {
-
-    @BeforeTest
-    fun initializeFirebase() {
-        Firebase.initialize(
-            context,
-            FirebaseOptions(
-                applicationId = "1:846484016111:ios:dd1f6688bad7af768c841a",
-                apiKey = "AIzaSyCK87dcMFhzCz_kJVs2cT2AVlqOTLuyWV0",
-                databaseUrl = "https://fir-kotlin-sdk.firebaseio.com",
-                storageBucket = "fir-kotlin-sdk.appspot.com",
-                projectId = "fir-kotlin-sdk"
+    companion object {
+        init {
+            // Firebase only wants to be initialized once.
+            Firebase.initialize(
+                context,
+                FirebaseOptions(
+                    applicationId = "1:846484016111:ios:dd1f6688bad7af768c841a",
+                    apiKey = "AIzaSyCK87dcMFhzCz_kJVs2cT2AVlqOTLuyWV0",
+                    databaseUrl = "https://fir-kotlin-sdk.firebaseio.com",
+                    storageBucket = "fir-kotlin-sdk.appspot.com",
+                    projectId = "fir-kotlin-sdk"
+                )
             )
-        )
+        }
     }
 
     @Test

--- a/firebase-auth/src/iosMain/kotlin/dev/gitlive/firebase/auth/auth.kt
+++ b/firebase-auth/src/iosMain/kotlin/dev/gitlive/firebase/auth/auth.kt
@@ -29,6 +29,9 @@ actual class FirebaseAuth internal constructor(val ios: FIRAuth) {
     actual suspend fun signInWithEmailAndPassword(email: String, password: String) =
         AuthResult(ios.awaitResult { signInWithEmail(email = email, password = password, completion = it) })
 
+    actual suspend fun createUserWithEmailAndPassword(email: String, password: String) =
+        AuthResult(ios.awaitResult { createUserWithEmail(email = email, password = password, completion = it) })
+
     actual suspend fun signInWithCustomToken(token: String) =
         AuthResult(ios.awaitResult { signInWithCustomToken(token, it) })
 

--- a/firebase-auth/src/jsMain/kotlin/dev/gitlive/firebase/auth/auth.kt
+++ b/firebase-auth/src/jsMain/kotlin/dev/gitlive/firebase/auth/auth.kt
@@ -23,6 +23,9 @@ actual class FirebaseAuth internal constructor(val js: firebase.auth.Auth) {
     actual suspend fun signInWithEmailAndPassword(email: String, password: String) =
      rethrow { AuthResult(js.signInWithEmailAndPassword(email, password).await()) }
 
+    actual suspend fun createUserWithEmailAndPassword(email: String, password: String) =
+     rethrow { AuthResult(js.createUserWithEmailAndPassword(email, password).await()) }
+
     actual suspend fun signInWithCustomToken(token: String)
             = rethrow { AuthResult(js.signInWithCustomToken(token).await()) }
 

--- a/firebase-common/src/jsMain/kotlin/dev/gitlive/firebase/externals.kt
+++ b/firebase-common/src/jsMain/kotlin/dev/gitlive/firebase/externals.kt
@@ -58,6 +58,7 @@ external object firebase {
             val currentUser: user.User?
 
             fun signInWithEmailAndPassword(email: String, password: String): Promise<AuthResult>
+            fun createUserWithEmailAndPassword(email: String, password: String): Promise<AuthResult>
             fun signInWithCustomToken(token: String): Promise<AuthResult>
             fun signInAnonymously(): Promise<AuthResult>
             fun signOut(): Promise<Unit>


### PR DESCRIPTION
Tested this together with `signInWithEmailAndPassword` on Android & it works.

Dunno if the JS / iOS implementation is correct but looking at a first glance it looks like!