### PR TITLE
Adding a missing FirebaseUser.isEmailVerified for all platforms

### DIFF
--- a/firebase-app/package.json
+++ b/firebase-app/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/GitLiveApp/firebase-kotlin-sdk",
   "dependencies": {
-    "@gitlive/firebase-common": "0",
+    "@gitlive/firebase-common": "0.3.1",
     "firebase": "7.14.0",
     "kotlin": "1.3.72",
     "kotlinx-coroutines-core": "1.3.5"

--- a/firebase-auth/package.json
+++ b/firebase-auth/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/GitLiveApp/firebase-kotlin-sdk",
   "dependencies": {
-    "@gitlive/firebase-app": "0",
+    "@gitlive/firebase-app": "0.3.1",
     "firebase": "7.14.0",
     "kotlin": "1.3.72",
     "kotlinx-coroutines-core": "1.3.5"

--- a/firebase-auth/src/androidMain/kotlin/dev/gitlive/firebase/auth/auth.kt
+++ b/firebase-auth/src/androidMain/kotlin/dev/gitlive/firebase/auth/auth.kt
@@ -70,6 +70,9 @@ actual class FirebaseUser internal constructor(val android: com.google.firebase.
         get() = android.phoneNumber
     actual val isAnonymous: Boolean
         get() = android.isAnonymous
+    actual val isEmailVerified: Boolean
+        get() = android.isEmailVerified
+
     actual suspend fun delete() = android.delete().await().run { Unit }
     actual suspend fun reload() = android.reload().await().run { Unit }
     actual suspend fun sendEmailVerification() = android.sendEmailVerification().await().run { Unit }

--- a/firebase-auth/src/commonMain/kotlin/dev/gitlive/firebase/auth/auth.kt
+++ b/firebase-auth/src/commonMain/kotlin/dev/gitlive/firebase/auth/auth.kt
@@ -37,6 +37,7 @@ expect class FirebaseUser {
     val email: String?
     val phoneNumber: String?
     val isAnonymous: Boolean
+    val isEmailVerified: Boolean
     suspend fun delete()
     suspend fun reload()
     suspend fun sendEmailVerification()

--- a/firebase-auth/src/iosMain/kotlin/dev/gitlive/firebase/auth/auth.kt
+++ b/firebase-auth/src/iosMain/kotlin/dev/gitlive/firebase/auth/auth.kt
@@ -69,6 +69,8 @@ actual class FirebaseUser internal constructor(val ios: FIRUser) {
         get() = ios.phoneNumber
     actual val isAnonymous: Boolean
         get() = ios.isAnonymous()
+    actual val isEmailVerified: Boolean
+        get() = ios.isEmailVerified
     actual suspend fun delete() = ios.await { deleteWithCompletion(it) }.run { Unit }
     actual suspend fun reload() = ios.await { reloadWithCompletion(it) }.run { Unit }
     actual suspend fun sendEmailVerification() = ios.await { sendEmailVerificationWithCompletion(it) }.run { Unit }

--- a/firebase-auth/src/jsMain/kotlin/dev/gitlive/firebase/auth/auth.kt
+++ b/firebase-auth/src/jsMain/kotlin/dev/gitlive/firebase/auth/auth.kt
@@ -66,6 +66,9 @@ actual class FirebaseUser internal constructor(val js: firebase.user.User) {
         get() = rethrow { js.phoneNumber }
     actual val isAnonymous: Boolean
         get() = rethrow { js.isAnonymous }
+    actual val isEmailVerified: Boolean
+    get() = rethrow { js.emailVerified }
+
     actual suspend fun delete() = rethrow { js.delete().await() }
     actual suspend fun reload() = rethrow { js.reload().await() }
     actual suspend fun sendEmailVerification() = rethrow { js.sendEmailVerification().await() }

--- a/firebase-auth/src/jsMain/kotlin/dev/gitlive/firebase/auth/auth.kt
+++ b/firebase-auth/src/jsMain/kotlin/dev/gitlive/firebase/auth/auth.kt
@@ -67,7 +67,7 @@ actual class FirebaseUser internal constructor(val js: firebase.user.User) {
     actual val isAnonymous: Boolean
         get() = rethrow { js.isAnonymous }
     actual val isEmailVerified: Boolean
-    get() = rethrow { js.emailVerified }
+        get() = rethrow { js.emailVerified }
 
     actual suspend fun delete() = rethrow { js.delete().await() }
     actual suspend fun reload() = rethrow { js.reload().await() }

--- a/firebase-common/src/jsMain/kotlin/dev/gitlive/firebase/externals.kt
+++ b/firebase-common/src/jsMain/kotlin/dev/gitlive/firebase/externals.kt
@@ -90,6 +90,7 @@ external object firebase {
             val email: String?
             val phoneNumber: String?
             val isAnonymous: Boolean
+            val emailVerified: Boolean
 
             fun delete(): Promise<Unit>
             fun reload(): Promise<Unit>

--- a/firebase-database/package.json
+++ b/firebase-database/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/GitLiveApp/firebase-kotlin-sdk",
   "dependencies": {
-    "@gitlive/firebase-app": "0",
+    "@gitlive/firebase-app": "0.3.1",
     "firebase": "7.14.0",
     "kotlin": "1.3.72",
     "kotlinx-coroutines-core": "1.3.5"

--- a/firebase-firestore/package.json
+++ b/firebase-firestore/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/GitLiveApp/firebase-kotlin-sdk",
   "dependencies": {
-    "@gitlive/firebase-app": "0",
+    "@gitlive/firebase-app": "0.3.1",
     "firebase": "7.14.0",
     "kotlin": "1.3.72",
     "kotlinx-coroutines-core": "1.3.5"

--- a/firebase-functions/package.json
+++ b/firebase-functions/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/GitLiveApp/firebase-kotlin-sdk",
   "dependencies": {
-    "@gitlive/firebase-app": "0",
+    "@gitlive/firebase-app": "0.3.1",
     "firebase": "7.14.0",
     "kotlin": "1.3.72",
     "kotlinx-coroutines-core": "1.3.5"


### PR DESCRIPTION
- Add `FirebaseUser.isEmailVerified` to `commonMain` 
- Add implementation for all platforms

Links to official documentation
- [iOS](https://firebase.google.com/docs/reference/swift/firebaseauth/api/reference/Classes/User#isemailverified)
- [AN](https://firebase.google.com/docs/reference/android/com/google/firebase/auth/UserInfo#isEmailVerified())
- [JS](https://firebase.google.com/docs/reference/js/firebase.User#emailverified)
