### PR TITLE
prevent accidental removal of photo URL

### DIFF
--- a/firebase-auth/src/androidMain/kotlin/dev/gitlive/firebase/auth/user.kt
+++ b/firebase-auth/src/androidMain/kotlin/dev/gitlive/firebase/auth/user.kt
@@ -48,7 +48,7 @@ actual class FirebaseUser internal constructor(val android: com.google.firebase.
     actual suspend fun updateProfile(displayName: String?, photoUrl: String?) {
         val request = UserProfileChangeRequest.Builder()
             .setDisplayName(displayName)
-            .setPhotoUri(photoURL?.let { Uri.parse(it) })
+            .setPhotoUri(photoUrl?.let { Uri.parse(it) })
             .build()
         android.updateProfile(request).await()
     }

--- a/firebase-auth/src/commonMain/kotlin/dev/gitlive/firebase/auth/user.kt
+++ b/firebase-auth/src/commonMain/kotlin/dev/gitlive/firebase/auth/user.kt
@@ -27,7 +27,7 @@ expect class FirebaseUser {
     suspend fun updateEmail(email: String)
     suspend fun updatePassword(password: String)
     suspend fun updatePhoneNumber(credential: PhoneAuthCredential)
-    suspend fun updateProfile(displayName: String? = null, photoUrl: String? = null)
+    suspend fun updateProfile(displayName: String? = this.displayName, photoUrl: String? = this.photoURL)
     suspend fun verifyBeforeUpdateEmail(newEmail: String, actionCodeSettings: ActionCodeSettings? = null)
 }
 


### PR DESCRIPTION
This PR fixes two issues with `updateProfile()` at once

 1. defaulting to null for display name and photo url will unset the value when set
 2. `photoUrl` was not used on _Android_