### PR TITLE
Add collection and document function

### DIFF
--- a/firebase-common/src/jsMain/kotlin/dev/gitlive/firebase/externals.kt
+++ b/firebase-common/src/jsMain/kotlin/dev/gitlive/firebase/externals.kt
@@ -361,6 +361,7 @@ external object firebase {
 
         open class CollectionReference : Query {
             val path: String
+            fun doc(path: String): DocumentReference
             fun add(data: Any): Promise<DocumentReference>
         }
 
@@ -388,6 +389,7 @@ external object firebase {
             val id: String
             val path: String
 
+            fun collection(path: String): CollectionReference
             fun get(options: Any? = definedExternally): Promise<DocumentSnapshot>
             fun set(data: Any, options: Any? = definedExternally): Promise<Unit>
             fun update(data: Any): Promise<Unit>

--- a/firebase-firestore/src/androidMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
+++ b/firebase-firestore/src/androidMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
@@ -329,6 +329,8 @@ actual class CollectionReference(override val android: com.google.firebase.fires
 
     actual suspend fun <T> add(data: T, strategy: SerializationStrategy<T>, encodeDefaults: Boolean) =
         DocumentReference(android.add(encode(strategy, data, encodeDefaults)!!).await())
+    actual suspend fun <T> add(strategy: SerializationStrategy<T>, data: T, encodeDefaults: Boolean) =
+        DocumentReference(android.add(encode(strategy, data, encodeDefaults)!!).await())
 }
 
 actual typealias FirebaseFirestoreException = com.google.firebase.firestore.FirebaseFirestoreException

--- a/firebase-firestore/src/androidMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
+++ b/firebase-firestore/src/androidMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
@@ -193,6 +193,8 @@ actual class DocumentReference(val android: com.google.firebase.firestore.Docume
     actual val path: String
         get() = android.path
 
+    actual fun collection(collectionPath: String) = CollectionReference(android.collection(collectionPath))
+
     actual suspend inline fun <reified T> set(data: T, encodeDefaults: Boolean, merge: Boolean) = when(merge) {
         true -> android.set(encode(data, encodeDefaults)!!, SetOptions.merge())
         false -> android.set(encode(data, encodeDefaults)!!)
@@ -323,6 +325,8 @@ actual class CollectionReference(override val android: com.google.firebase.fires
 
     actual val path: String
         get() = android.path
+
+    actual fun document(documentPath: String) = DocumentReference(android.document(documentPath))
 
     actual suspend inline fun <reified T> add(data: T, encodeDefaults: Boolean) =
         DocumentReference(android.add(encode(data, encodeDefaults)!!).await())

--- a/firebase-firestore/src/commonMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
+++ b/firebase-firestore/src/commonMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
@@ -126,7 +126,7 @@ expect class CollectionReference : Query {
 
     fun document(documentPath: String): DocumentReference
     suspend inline fun <reified T> add(data: T, encodeDefaults: Boolean = true): DocumentReference
-    @Deprecated("This will be deprecated in the near future")
+    @Deprecated("This will be replaced with add(strategy: SerializationStrategy<T>, data: T, encodeDefaults: Boolean = true)")
     suspend fun <T> add(data: T, strategy: SerializationStrategy<T>, encodeDefaults: Boolean = true): DocumentReference
     suspend fun <T> add(strategy: SerializationStrategy<T>, data: T, encodeDefaults: Boolean = true): DocumentReference
 }

--- a/firebase-firestore/src/commonMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
+++ b/firebase-firestore/src/commonMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
@@ -122,7 +122,9 @@ expect class DocumentReference {
 expect class CollectionReference : Query {
     val path: String
     suspend inline fun <reified T> add(data: T, encodeDefaults: Boolean = true): DocumentReference
+    @Deprecated
     suspend fun <T> add(data: T, strategy: SerializationStrategy<T>, encodeDefaults: Boolean = true): DocumentReference
+    suspend fun <T> add(strategy: SerializationStrategy<T>, data: T, encodeDefaults: Boolean = true): DocumentReference
 }
 
 expect class FirebaseFirestoreException : FirebaseException

--- a/firebase-firestore/src/commonMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
+++ b/firebase-firestore/src/commonMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
@@ -100,6 +100,8 @@ expect class DocumentReference {
     val id: String
     val path: String
     val snapshots: Flow<DocumentSnapshot>
+
+    fun collection(collectionPath: String): CollectionReference
     suspend fun get(): DocumentSnapshot
 
     suspend inline fun <reified T> set(data: T, encodeDefaults: Boolean = true, merge: Boolean = false)
@@ -121,8 +123,10 @@ expect class DocumentReference {
 
 expect class CollectionReference : Query {
     val path: String
+
+    fun document(documentPath: String): DocumentReference
     suspend inline fun <reified T> add(data: T, encodeDefaults: Boolean = true): DocumentReference
-    @Deprecated
+    @Deprecated("This will be deprecated in the near future")
     suspend fun <T> add(data: T, strategy: SerializationStrategy<T>, encodeDefaults: Boolean = true): DocumentReference
     suspend fun <T> add(strategy: SerializationStrategy<T>, data: T, encodeDefaults: Boolean = true): DocumentReference
 }

--- a/firebase-firestore/src/commonTest/kotlin/dev/gitlive/firebase/firestore/firestore.kt
+++ b/firebase-firestore/src/commonTest/kotlin/dev/gitlive/firebase/firestore/firestore.kt
@@ -99,8 +99,8 @@ class FirebaseFirestoreTest {
     }
 
     private suspend fun setupFirestoreData() {
-        Firebase.firestore.document("test/one").set(FirestoreTest.serializer(), FirestoreTest("aaa"))
-        Firebase.firestore.document("test/two").set(FirestoreTest.serializer(), FirestoreTest("bbb"))
-        Firebase.firestore.document("test/three").set(FirestoreTest.serializer(), FirestoreTest("ccc"))
+        Firebase.firestore.collection("test").document("one").set(FirestoreTest("aaa"))
+        Firebase.firestore.collection("test").document("two").set(FirestoreTest("bbb"))
+        Firebase.firestore.collection("test").document("three").set(FirestoreTest("ccc"))
     }
 }

--- a/firebase-firestore/src/commonTest/kotlin/dev/gitlive/firebase/firestore/firestore.kt
+++ b/firebase-firestore/src/commonTest/kotlin/dev/gitlive/firebase/firestore/firestore.kt
@@ -99,8 +99,8 @@ class FirebaseFirestoreTest {
     }
 
     private suspend fun setupFirestoreData() {
-        Firebase.firestore.collection("test").document("one").set(FirestoreTest("aaa"))
-        Firebase.firestore.collection("test").document("two").set(FirestoreTest("bbb"))
-        Firebase.firestore.collection("test").document("three").set(FirestoreTest("ccc"))
+        Firebase.firestore.collection("test").document("one").set(FirestoreTest.serializer(), FirestoreTest("aaa"))
+        Firebase.firestore.collection("test").document("two").set(FirestoreTest.serializer(), FirestoreTest("bbb"))
+        Firebase.firestore.collection("test").document("three").set(FirestoreTest.serializer(), FirestoreTest("ccc"))
     }
 }

--- a/firebase-firestore/src/iosMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
+++ b/firebase-firestore/src/iosMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
@@ -237,6 +237,8 @@ actual class CollectionReference(override val ios: FIRCollectionReference) : Que
 
     actual suspend fun <T> add(data: T, strategy: SerializationStrategy<T>, encodeDefaults: Boolean) =
         DocumentReference(await { ios.addDocumentWithData(encode(strategy, data, encodeDefaults) as Map<Any?, *>) })
+    actual suspend fun <T> add(strategy: SerializationStrategy<T>, data: T, encodeDefaults: Boolean) =
+        DocumentReference(await { ios.addDocumentWithData(encode(strategy, data, encodeDefaults) as Map<Any?, *>) })
 }
 
 actual class FirebaseFirestoreException(message: String, val code: FirestoreExceptionCode) : FirebaseException(message)

--- a/firebase-firestore/src/iosMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
+++ b/firebase-firestore/src/iosMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
@@ -131,6 +131,8 @@ actual class DocumentReference(val ios: FIRDocumentReference) {
     actual val path: String
         get() = ios.path
 
+    actual fun collection(collectionPath: String) = CollectionReference(ios.collectionWithPath(collectionPath))
+
     actual suspend inline fun <reified T> set(data: T, encodeDefaults: Boolean, merge: Boolean) =
         await { ios.setData(encode(data, encodeDefaults)!! as Map<Any?, *>, merge, it) }
 
@@ -231,6 +233,8 @@ actual class CollectionReference(override val ios: FIRCollectionReference) : Que
 
     actual val path: String
         get() = ios.path
+
+    actual fun document(documentPath: String) = DocumentReference(ios.documentWithPath(documentPath))
 
     actual suspend inline fun <reified T> add(data: T, encodeDefaults: Boolean) =
         DocumentReference(await { ios.addDocumentWithData(encode(data, encodeDefaults) as Map<Any?, *>, it) })

--- a/firebase-firestore/src/jsMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
+++ b/firebase-firestore/src/jsMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
@@ -315,6 +315,8 @@ actual class CollectionReference(override val js: firebase.firestore.CollectionR
 
     actual suspend fun <T> add(data: T, strategy: SerializationStrategy<T>, encodeDefaults: Boolean) =
         rethrow { DocumentReference(js.add(encode(strategy, data, encodeDefaults)!!).await()) }
+    actual suspend fun <T> add(strategy: SerializationStrategy<T>, data: T, encodeDefaults: Boolean) =
+        rethrow { DocumentReference(js.add(encode(strategy, data, encodeDefaults)!!).await()) }
 }
 
 actual class FirebaseFirestoreException(cause: Throwable, val code: FirestoreExceptionCode) : FirebaseException(code.toString(), cause)

--- a/firebase-firestore/src/jsMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
+++ b/firebase-firestore/src/jsMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
@@ -184,6 +184,8 @@ actual class DocumentReference(val js: firebase.firestore.DocumentReference) {
     actual val path: String
         get() = rethrow { js.path }
 
+    actual fun collection(collectionPath: String) = rethrow { CollectionReference(js.collection(collectionPath)) }
+
     actual suspend inline fun <reified T> set(data: T, encodeDefaults: Boolean, merge: Boolean) =
         rethrow { js.set(encode(data, encodeDefaults)!!, json("merge" to merge)).await() }
 
@@ -309,6 +311,8 @@ actual class CollectionReference(override val js: firebase.firestore.CollectionR
 
     actual val path: String
         get() =  rethrow { js.path }
+
+    actual fun document(documentPath: String) = rethrow { DocumentReference(js.doc(documentPath)) }
 
     actual suspend inline fun <reified T> add(data: T, encodeDefaults: Boolean) =
         rethrow { DocumentReference(js.add(encode(data, encodeDefaults)!!).await()) }


### PR DESCRIPTION
Added the collection and document function so that you can string together the collections and docs like so: `firestore.collection('col1').document('doc1').collection('col2').document('doc2')`. Went with `document` as the most of the SDKs use `document` instead of `doc` which is only used in js.

Deprecated 
```kotlin
suspend fun <T> add(data: T, strategy: SerializationStrategy<T>, encodeDefaults: Boolean = true): DocumentReference
``` 
for
```kotlin
suspend fun <T> add(strategy: SerializationStrategy<T>, data: T, encodeDefaults: Boolean = true): DocumentReference
``` 
to match the parameters of the `set` methods 