### PR TITLE
Fix FieldValue.arrayRemove on iOS

### DIFF
--- a/firebase-firestore/src/iosMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
+++ b/firebase-firestore/src/iosMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
@@ -402,7 +402,7 @@ actual object FieldValue {
     actual val serverTimestamp = Double.POSITIVE_INFINITY
     actual val delete: Any get() = FIRFieldValue.fieldValueForDelete()
     actual fun arrayUnion(vararg elements: Any): Any = FIRFieldValue.fieldValueForArrayUnion(elements.asList())
-    actual fun arrayRemove(vararg elements: Any): Any = FIRFieldValue.fieldValueForArrayUnion(elements.asList())
+    actual fun arrayRemove(vararg elements: Any): Any = FIRFieldValue.fieldValueForArrayRemove(elements.asList())
     actual fun delete(): Any = delete
 }
 


### PR DESCRIPTION
**Issue**
https://github.com/GitLiveApp/firebase-kotlin-sdk/issues/173

**Actual Implementation**
`FieldValue.arrayRemove(...)` is calling: 
`FIRFieldValue.fieldValueForArrayUnion(elements.asList())` 

**Updated Implementation**
`FieldValue.arrayRemove(...)` should call: 
`FIRFieldValue.fieldValueForArrayRemove(elements.asList())` 