### PR TITLE
Update broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <i>Real-time code collaboration inside any IDE</i><br/>
 <br/>
 <br/>
-The Firebase Kotlin SDK is a Kotlin-first SDK for Firebase. It's API is similar to the [Firebase Android SDK Kotlin Extensions](https://firebase.github.io/firebase-android-sdk/reference/kotlin/firebase-ktx/) but also supports multiplatform projects, enabling you to use Firebase directly from your common source targeting *iOS*, *Android* or *JS*.
+The Firebase Kotlin SDK is a Kotlin-first SDK for Firebase. It's API is similar to the <a href="https://firebase.github.io/firebase-android-sdk/reference/kotlin/firebase-ktx/">Firebase Android SDK Kotlin Extensions</a> but also supports multiplatform projects, enabling you to use Firebase directly from your common source targeting <strong>iOS</strong>, <strong>Android</strong> or <strong>JS</strong>.
 
 ## Available libraries
 


### PR DESCRIPTION
Links and bold were using markdown format, but weren't being interpreted as links.
Converted from markdown `[link](url)` format to HTML `<a href="link">words</a>` format.