### PR TITLE
Fix iOS tests, upgrade iOS Firebase SDK

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -30,12 +30,20 @@ jobs:
       run: ./gradlew assemble
     - name: Run JS Tests
       run: ./gradlew cleanTest jsTest
-    - name: Upload test artifact
+    - name: Upload JS test artifact
       uses: actions/upload-artifact@v2
       if: failure()
       with:
-        name: "JSTest Report HTML"
+        name: "JS Test Report HTML"
         path: "firebase-firestore/build/reports/tests/jsTest/"
+    - name: Run iOS Tests
+      run: ./gradlew cleanTest iosTest
+    - name: Upload iOS test artifact
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: "iOS Test Report HTML"
+        path: "firebase-firestore/build/reports/tests/iosTest/"
     - name: Run Android Instrumented Tests
       uses: reactivecircus/android-emulator-runner@v2
       with:
@@ -44,3 +52,9 @@ jobs:
         arch: x86_64
         profile: Nexus 6
         script: ./gradlew connectedAndroidTest
+    - name: Upload Android test artifact
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: "Android Test Report HTML"
+        path: "firebase-firestore/build/reports/tests/androidTests/"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -37,7 +37,7 @@ jobs:
         name: "JS Test Report HTML"
         path: "firebase-firestore/build/reports/tests/jsTest/"
     - name: Run iOS Tests
-      run: ./gradlew cleanTest iosTest
+      run: ./gradlew cleanTest iosX64Test
     - name: Upload iOS test artifact
       uses: actions/upload-artifact@v2
       if: failure()

--- a/firebase-app/src/nativeInterop/cinterop/Cartfile
+++ b/firebase-app/src/nativeInterop/cinterop/Cartfile
@@ -1,1 +1,1 @@
-binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json" == 8.1.1
+binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json" == 8.2.0

--- a/firebase-app/src/nativeInterop/cinterop/FirebaseCore.def
+++ b/firebase-app/src/nativeInterop/cinterop/FirebaseCore.def
@@ -2,4 +2,4 @@ language = Objective-C
 package = cocoapods.FirebaseCore
 modules = FirebaseCore
 compilerOpts = -framework FirebaseCore
-linkerOpts = -framework FirebaseCore -framework FirebaseCoreDiagnostics -framework FirebaseAnalytics -framework FIRAnalyticsConnector -framework GoogleAppMeasurement -framework FirebaseInstallations -framework GoogleDataTransport  -framework GoogleUtilities -framework PromisesObjC -framework nanopb -framework StoreKit -lsqlite3
+linkerOpts = -framework FirebaseCore -framework FirebaseCoreDiagnostics -framework FirebaseAnalytics -framework GoogleAppMeasurement -framework FirebaseInstallations -framework GoogleDataTransport  -framework GoogleUtilities -framework PromisesObjC -framework nanopb -framework StoreKit -lsqlite3

--- a/firebase-auth/build.gradle.kts
+++ b/firebase-auth/build.gradle.kts
@@ -79,6 +79,22 @@ kotlin {
             rootProject.project("firebase-app").projectDir.resolve("src/nativeInterop/cinterop/Carthage/Build/iOS")
         ).plus(
             listOf(
+                "FirebaseAnalytics",
+                "FirebaseCore",
+                "FirebaseCoreDiagnostics",
+                "FirebaseInstallations",
+                "GoogleAppMeasurement",
+                "GoogleDataTransport",
+                "GoogleUtilities",
+                "nanopb",
+                "PromisesObjC"
+            ).map {
+                val archVariant = if (konanTarget is KonanTarget.IOS_X64) "ios-arm64_i386_x86_64-simulator" else "ios-arm64_armv7"
+
+                rootProject.project("firebase-app").projectDir.resolve("src/nativeInterop/cinterop/Carthage/Build/$it.xcframework/$archVariant")
+            }
+        ).plus(
+            listOf(
                 "FirebaseAuth",
                 "GTMSessionFetcher"
             ).map {

--- a/firebase-auth/src/androidAndroidTest/kotlin/dev/gitlive/firebase/auth/auth.kt
+++ b/firebase-auth/src/androidAndroidTest/kotlin/dev/gitlive/firebase/auth/auth.kt
@@ -13,7 +13,7 @@ actual val emulatorHost: String = "10.0.2.2"
 
 actual val context: Any = InstrumentationRegistry.getInstrumentation().targetContext
 
-actual val currentPlatform: TargetPlatform = TargetPlatform.Android
+actual val currentPlatform: Platform = Platform.Android
 
 actual fun runTest(skip: Boolean, test: suspend () -> Unit) = runBlocking {
     if (skip) {

--- a/firebase-auth/src/androidAndroidTest/kotlin/dev/gitlive/firebase/auth/auth.kt
+++ b/firebase-auth/src/androidAndroidTest/kotlin/dev/gitlive/firebase/auth/auth.kt
@@ -5,6 +5,7 @@
 @file:JvmName("tests")
 package dev.gitlive.firebase.auth
 
+import android.util.Log
 import androidx.test.platform.app.InstrumentationRegistry
 import kotlinx.coroutines.runBlocking
 
@@ -12,4 +13,14 @@ actual val emulatorHost: String = "10.0.2.2"
 
 actual val context: Any = InstrumentationRegistry.getInstrumentation().targetContext
 
-actual fun runTest(test: suspend () -> Unit) = runBlocking { test() }
+actual val currentPlatform: TargetPlatform = TargetPlatform.Android
+
+actual fun runTest(skip: Boolean, test: suspend () -> Unit) = runBlocking {
+    if (skip) {
+        Log.w("Test", "Skip the test.")
+        return@runBlocking
+    }
+
+    test()
+}
+

--- a/firebase-auth/src/commonTest/kotlin/dev/gitlive/firebase/auth/auth.kt
+++ b/firebase-auth/src/commonTest/kotlin/dev/gitlive/firebase/auth/auth.kt
@@ -10,9 +10,15 @@ import kotlin.test.*
 
 expect val emulatorHost: String
 expect val context: Any
-expect fun runTest(test: suspend () -> Unit)
+expect fun runTest(skip: Boolean = false, test: suspend () -> Unit)
+expect val currentPlatform: TargetPlatform
+
+enum class TargetPlatform { Android, IOS, JS }
 
 class FirebaseAuthTest {
+
+    // Skip the tests on iOS simulator due keychain exceptions
+    private val skip = currentPlatform == TargetPlatform.IOS
 
     @BeforeTest
     fun initializeFirebase() {
@@ -35,14 +41,14 @@ class FirebaseAuthTest {
     }
 
     @Test
-    fun testSignInWithUsernameAndPassword() = runTest {
+    fun testSignInWithUsernameAndPassword() = runTest(skip) {
         val uid = getTestUid("test@test.com", "test123")
         val result = Firebase.auth.signInWithEmailAndPassword("test@test.com", "test123")
         assertEquals(uid, result.user!!.uid)
     }
 
     @Test
-    fun testCreateUserWithEmailAndPassword() = runTest {
+    fun testCreateUserWithEmailAndPassword() = runTest(skip) {
         val email = "test+${Random.nextInt(100000)}@test.com"
         val createResult = Firebase.auth.createUserWithEmailAndPassword(email, "test123")
         assertNotEquals(null, createResult.user?.uid)
@@ -57,7 +63,7 @@ class FirebaseAuthTest {
     }
 
     @Test
-    fun testFetchSignInMethods() = runTest {
+    fun testFetchSignInMethods() = runTest(skip) {
         val email = "test+${Random.nextInt(100000)}@test.com"
         var signInMethodResult = Firebase.auth.fetchSignInMethodsForEmail(email)
         assertEquals(emptyList(), signInMethodResult)
@@ -69,7 +75,7 @@ class FirebaseAuthTest {
     }
 
     @Test
-    fun testSendEmailVerification() = runTest {
+    fun testSendEmailVerification() = runTest(skip) {
         val email = "test+${Random.nextInt(100000)}@test.com"
         val createResult = Firebase.auth.createUserWithEmailAndPassword(email, "test123")
         assertNotEquals(null, createResult.user?.uid)
@@ -79,7 +85,7 @@ class FirebaseAuthTest {
     }
 
     @Test
-    fun sendPasswordResetEmail() = runTest {
+    fun sendPasswordResetEmail() = runTest(skip) {
         val email = "test+${Random.nextInt(100000)}@test.com"
         val createResult = Firebase.auth.createUserWithEmailAndPassword(email, "test123")
         assertNotEquals(null, createResult.user?.uid)
@@ -90,7 +96,7 @@ class FirebaseAuthTest {
     }
 
     @Test
-    fun testSignInWithCredential() = runTest {
+    fun testSignInWithCredential() = runTest(skip) {
         val uid = getTestUid("test@test.com", "test123")
         val credential = EmailAuthProvider.credential("test@test.com", "test123")
         val result = Firebase.auth.signInWithCredential(credential)

--- a/firebase-auth/src/commonTest/kotlin/dev/gitlive/firebase/auth/auth.kt
+++ b/firebase-auth/src/commonTest/kotlin/dev/gitlive/firebase/auth/auth.kt
@@ -11,14 +11,14 @@ import kotlin.test.*
 expect val emulatorHost: String
 expect val context: Any
 expect fun runTest(skip: Boolean = false, test: suspend () -> Unit)
-expect val currentPlatform: TargetPlatform
+expect val currentPlatform: Platform
 
-enum class TargetPlatform { Android, IOS, JS }
+enum class Platform { Android, IOS, JS }
 
 class FirebaseAuthTest {
 
     // Skip the tests on iOS simulator due keychain exceptions
-    private val skip = currentPlatform == TargetPlatform.IOS
+    private val skip = currentPlatform == Platform.IOS
 
     @BeforeTest
     fun initializeFirebase() {

--- a/firebase-auth/src/iosTest/kotlin/dev/gitlive/firebase/auth/auth.kt
+++ b/firebase-auth/src/iosTest/kotlin/dev/gitlive/firebase/auth/auth.kt
@@ -11,7 +11,7 @@ actual val emulatorHost: String = "localhost"
 
 actual val context: Any = Unit
 
-actual val currentPlatform: TargetPlatform = TargetPlatform.IOS
+actual val currentPlatform: Platform = Platform.IOS
 
 actual fun runTest(skip: Boolean, test: suspend () -> Unit) = runBlocking {
     if (skip) {

--- a/firebase-auth/src/iosTest/kotlin/dev/gitlive/firebase/auth/auth.kt
+++ b/firebase-auth/src/iosTest/kotlin/dev/gitlive/firebase/auth/auth.kt
@@ -11,7 +11,14 @@ actual val emulatorHost: String = "localhost"
 
 actual val context: Any = Unit
 
-actual fun runTest(test: suspend () -> Unit) = runBlocking {
+actual val currentPlatform: TargetPlatform = TargetPlatform.IOS
+
+actual fun runTest(skip: Boolean, test: suspend () -> Unit) = runBlocking {
+    if (skip) {
+        NSLog("Skip the test.")
+        return@runBlocking
+    }
+
     val testRun = MainScope().async { test() }
     while (testRun.isActive) {
         NSRunLoop.mainRunLoop.runMode(

--- a/firebase-auth/src/jsTest/kotlin/dev/gitlive/firebase/auth/auth.kt
+++ b/firebase-auth/src/jsTest/kotlin/dev/gitlive/firebase/auth/auth.kt
@@ -11,8 +11,15 @@ actual val emulatorHost: String = "localhost"
 
 actual val context: Any = Unit
 
-actual fun runTest(test: suspend () -> Unit) = GlobalScope
+actual val currentPlatform: TargetPlatform = TargetPlatform.JS
+
+actual fun runTest(skip: Boolean, test: suspend () -> Unit) = GlobalScope
     .promise {
+        if (skip) {
+            console.log("Skip the test.")
+            return@promise
+        }
+
         try {
             test()
         } catch (e: dynamic) {

--- a/firebase-auth/src/jsTest/kotlin/dev/gitlive/firebase/auth/auth.kt
+++ b/firebase-auth/src/jsTest/kotlin/dev/gitlive/firebase/auth/auth.kt
@@ -11,7 +11,7 @@ actual val emulatorHost: String = "localhost"
 
 actual val context: Any = Unit
 
-actual val currentPlatform: TargetPlatform = TargetPlatform.JS
+actual val currentPlatform: Platform = Platform.JS
 
 actual fun runTest(skip: Boolean, test: suspend () -> Unit) = GlobalScope
     .promise {

--- a/firebase-auth/src/nativeInterop/cinterop/Cartfile
+++ b/firebase-auth/src/nativeInterop/cinterop/Cartfile
@@ -1,1 +1,1 @@
-binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAuthBinary.json" == 8.1.0
+binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAuthBinary.json" == 8.2.0

--- a/firebase-database/build.gradle.kts
+++ b/firebase-database/build.gradle.kts
@@ -55,6 +55,22 @@ kotlin {
             rootProject.project("firebase-app").projectDir.resolve("src/nativeInterop/cinterop/Carthage/Build/iOS")
         ).plus(
             listOf(
+                "FirebaseAnalytics",
+                "FirebaseCore",
+                "FirebaseCoreDiagnostics",
+                "FirebaseInstallations",
+                "GoogleAppMeasurement",
+                "GoogleDataTransport",
+                "GoogleUtilities",
+                "nanopb",
+                "PromisesObjC"
+            ).map {
+                val archVariant = if (konanTarget is KonanTarget.IOS_X64) "ios-arm64_i386_x86_64-simulator" else "ios-arm64_armv7"
+
+                rootProject.project("firebase-app").projectDir.resolve("src/nativeInterop/cinterop/Carthage/Build/$it.xcframework/$archVariant")
+            }
+        ).plus(
+            listOf(
                 "FirebaseDatabase",
                 "leveldb-library"
             ).map {

--- a/firebase-database/src/nativeInterop/cinterop/Cartfile
+++ b/firebase-database/src/nativeInterop/cinterop/Cartfile
@@ -1,1 +1,1 @@
-binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseDatabaseBinary.json" == 8.1.0
+binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseDatabaseBinary.json" == 8.2.0

--- a/firebase-firestore/build.gradle.kts
+++ b/firebase-firestore/build.gradle.kts
@@ -57,10 +57,27 @@ kotlin {
             rootProject.project("firebase-app").projectDir.resolve("src/nativeInterop/cinterop/Carthage/Build/iOS")
         ).plus(
             listOf(
+                "FirebaseAnalytics",
+                "FirebaseCore",
+                "FirebaseCoreDiagnostics",
+                "FirebaseInstallations",
+                "GoogleAppMeasurement",
+                "GoogleDataTransport",
+                "GoogleUtilities",
+                "nanopb",
+                "PromisesObjC"
+            ).map {
+                val archVariant = if (konanTarget is KonanTarget.IOS_X64) "ios-arm64_i386_x86_64-simulator" else "ios-arm64_armv7"
+
+                rootProject.project("firebase-app").projectDir.resolve("src/nativeInterop/cinterop/Carthage/Build/$it.xcframework/$archVariant")
+            }
+        ).plus(
+            listOf(
                 "abseil",
                 "BoringSSL-GRPC",
                 "FirebaseFirestore",
                 "gRPC-Core",
+                "gRPC-C++",
                 "leveldb-library"
             ).map {
                 val archVariant = if (konanTarget is KonanTarget.IOS_X64) "ios-arm64_i386_x86_64-simulator" else "ios-arm64_armv7"

--- a/firebase-firestore/src/nativeInterop/cinterop/Cartfile
+++ b/firebase-firestore/src/nativeInterop/cinterop/Cartfile
@@ -1,1 +1,1 @@
-binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseFirestoreBinary.json" == 8.1.0
+binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseFirestoreBinary.json" == 8.2.0

--- a/firebase-functions/build.gradle.kts
+++ b/firebase-functions/build.gradle.kts
@@ -49,6 +49,22 @@ kotlin {
             rootProject.project("firebase-app").projectDir.resolve("src/nativeInterop/cinterop/Carthage/Build/iOS")
         ).plus(
             listOf(
+                "FirebaseAnalytics",
+                "FirebaseCore",
+                "FirebaseCoreDiagnostics",
+                "FirebaseInstallations",
+                "GoogleAppMeasurement",
+                "GoogleDataTransport",
+                "GoogleUtilities",
+                "nanopb",
+                "PromisesObjC"
+            ).map {
+                val archVariant = if (konanTarget is KonanTarget.IOS_X64) "ios-arm64_i386_x86_64-simulator" else "ios-arm64_armv7"
+
+                rootProject.project("firebase-app").projectDir.resolve("src/nativeInterop/cinterop/Carthage/Build/$it.xcframework/$archVariant")
+            }
+        ).plus(
+            listOf(
                 "FirebaseFunctions",
                 "GTMSessionFetcher"
             ).map {

--- a/firebase-functions/src/nativeInterop/cinterop/Cartfile
+++ b/firebase-functions/src/nativeInterop/cinterop/Cartfile
@@ -1,1 +1,1 @@
-binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseFunctionsBinary.json" == 8.1.0
+binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseFunctionsBinary.json" == 8.2.0


### PR DESCRIPTION
After updating Firebase iOS SDK some tests fail because `ld` could not find the required frameworks. 
Another problem, FirebaseFirestore 8.1.0 has Carthage [bug](https://github.com/firebase/firebase-ios-sdk/issues/8112) that is the cause of missing gRPC-C++ framework. This PR fixes these issues. Also, I've enabled iOS testing at GitHub actions. Unfortunately, auth tests fail on iOS simulator, therefore I've added a skip flag for ignoring tests on iOS.