### PR TITLE
Gl 861 add ability to skip ios tests for firebase

### DIFF
--- a/firebase-app/build.gradle.kts
+++ b/firebase-app/build.gradle.kts
@@ -153,7 +153,7 @@ kotlin {
 
 if (project.property("firebase-app.skipIosTests") == "true") {
     tasks.forEach {
-        if (it.name.contains("ios") && it.name.contains("test")) { it.enabled = false }
+        if (it.name.contains("ios", true) && it.name.contains("test", true)) { it.enabled = false }
     }
 }
 

--- a/firebase-app/build.gradle.kts
+++ b/firebase-app/build.gradle.kts
@@ -58,8 +58,6 @@ kotlin {
     }
 
     val supportIosTarget = project.property("skipIosTarget") != "true"
-    val runIosTests = project.property("firebase-app.skipIosTests") != "true"
-
     if (supportIosTarget) {
 
         fun nativeTargetConfig(): KotlinNativeTarget.() -> Unit = {
@@ -144,14 +142,18 @@ kotlin {
             val iosSimulatorArm64Main by getting
             iosSimulatorArm64Main.dependsOn(iosMain)
 
-            if (runIosTests) {
-                val iosTest by sourceSets.getting
-                val iosSimulatorArm64Test by sourceSets.getting
-                iosSimulatorArm64Test.dependsOn(iosTest)
-            }
+            val iosTest by sourceSets.getting
+            val iosSimulatorArm64Test by sourceSets.getting
+            iosSimulatorArm64Test.dependsOn(iosTest)
         }
 
         val jsMain by getting
+    }
+}
+
+if (project.property("firebase-app.skipIosTests") == "true") {
+    tasks.forEach {
+        if (it.name.contains("ios") && it.name.contains("test")) { it.enabled = false }
     }
 }
 

--- a/firebase-app/build.gradle.kts
+++ b/firebase-app/build.gradle.kts
@@ -58,7 +58,7 @@ kotlin {
     }
 
     val supportIosTarget = project.property("skipIosTarget") != "true"
-    val runIosTests = project.property("skipIosTests") != "true"
+    val runIosTests = project.property("firebase-app.skipIosTests") != "true"
 
     if (supportIosTarget) {
 

--- a/firebase-app/build.gradle.kts
+++ b/firebase-app/build.gradle.kts
@@ -57,42 +57,48 @@ kotlin {
         publishAllLibraryVariants()
     }
 
-    fun nativeTargetConfig(): KotlinNativeTarget.() -> Unit = {
-        val nativeFrameworkPaths = listOf(
-            projectDir.resolve("src/nativeInterop/cinterop/Carthage/Build/iOS")
-        ).plus(
-            listOf(
-                "FirebaseAnalytics",
-                "FirebaseCore",
-                "FirebaseCoreDiagnostics",
-                "FirebaseInstallations",
-                "GoogleAppMeasurement",
-                "GoogleDataTransport",
-                "GoogleUtilities",
-                "nanopb",
-                "PromisesObjC"
-            ).map {
-                projectDir.resolve("src/nativeInterop/cinterop/Carthage/Build/$it.xcframework/${konanTarget.archVariant}")
-            }
-        )
+    val supportIosTarget = project.property("skipIosTarget") != "true"
+    val runIosTests = project.property("skipIosTests") != "true"
 
-        binaries {
-            getTest("DEBUG").apply {
-                linkerOpts(nativeFrameworkPaths.map { "-F$it" })
-                linkerOpts("-ObjC")
+    if (supportIosTarget) {
+
+        fun nativeTargetConfig(): KotlinNativeTarget.() -> Unit = {
+            val nativeFrameworkPaths = listOf(
+                projectDir.resolve("src/nativeInterop/cinterop/Carthage/Build/iOS")
+            ).plus(
+                listOf(
+                    "FirebaseAnalytics",
+                    "FirebaseCore",
+                    "FirebaseCoreDiagnostics",
+                    "FirebaseInstallations",
+                    "GoogleAppMeasurement",
+                    "GoogleDataTransport",
+                    "GoogleUtilities",
+                    "nanopb",
+                    "PromisesObjC"
+                ).map {
+                    projectDir.resolve("src/nativeInterop/cinterop/Carthage/Build/$it.xcframework/${konanTarget.archVariant}")
+                }
+            )
+
+            binaries {
+                getTest("DEBUG").apply {
+                    linkerOpts(nativeFrameworkPaths.map { "-F$it" })
+                    linkerOpts("-ObjC")
+                }
+            }
+
+            compilations.getByName("main") {
+                cinterops.create("FirebaseCore") {
+                    compilerOpts(nativeFrameworkPaths.map { "-F$it" })
+                    extraOpts("-verbose")
+                }
             }
         }
 
-        compilations.getByName("main") {
-            cinterops.create("FirebaseCore") {
-                compilerOpts(nativeFrameworkPaths.map { "-F$it" })
-                extraOpts("-verbose")
-            }
-        }
+        ios(configure = nativeTargetConfig())
+        iosSimulatorArm64(configure = nativeTargetConfig())
     }
-
-    ios(configure = nativeTargetConfig())
-    iosSimulatorArm64(configure = nativeTargetConfig())
 
     js {
         useCommonJs()
@@ -133,13 +139,17 @@ kotlin {
             }
         }
 
-        val iosMain by getting
-        val iosSimulatorArm64Main by getting
-        iosSimulatorArm64Main.dependsOn(iosMain)
+        if (supportIosTarget) {
+            val iosMain by getting
+            val iosSimulatorArm64Main by getting
+            iosSimulatorArm64Main.dependsOn(iosMain)
 
-        val iosTest by sourceSets.getting
-        val iosSimulatorArm64Test by sourceSets.getting
-        iosSimulatorArm64Test.dependsOn(iosTest)
+            if (runIosTests) {
+                val iosTest by sourceSets.getting
+                val iosSimulatorArm64Test by sourceSets.getting
+                iosSimulatorArm64Test.dependsOn(iosTest)
+            }
+        }
 
         val jsMain by getting
     }

--- a/firebase-auth/build.gradle.kts
+++ b/firebase-auth/build.gradle.kts
@@ -81,9 +81,6 @@ kotlin {
     }
 
     val supportIosTarget = project.property("skipIosTarget") != "true"
-    val runIosTests = project.property("firebase-auth.skipIosTests") != "true"
-
-    println("supportIosTarget: $supportIosTarget runIosTests $runIosTests")
     if (supportIosTarget) {
 
         fun nativeTargetConfig(): KotlinNativeTarget.() -> Unit = {
@@ -183,10 +180,13 @@ kotlin {
 
         val jsMain by getting
     }
+}
 
-    if (!runIosTests) {
-        tasks.forEach {
-            if (it.name.contains("ios") && it.name.contains("test")) { it.enabled = false }
+if (project.property("firebase-auth.skipIosTests") == "true") {
+    tasks.forEach {
+        if (it.name.contains("ios") && it.name.contains("test")) {
+            println("Skipping ${it.name}")
+            it.enabled = false
         }
     }
 }

--- a/firebase-auth/build.gradle.kts
+++ b/firebase-auth/build.gradle.kts
@@ -176,11 +176,9 @@ kotlin {
             val iosSimulatorArm64Main by getting
             iosSimulatorArm64Main.dependsOn(iosMain)
 
-            if (runIosTests) {
-                val iosTest by sourceSets.getting
-                val iosSimulatorArm64Test by sourceSets.getting
-                iosSimulatorArm64Test.dependsOn(iosTest)
-            }
+            val iosTest by sourceSets.getting
+            val iosSimulatorArm64Test by sourceSets.getting
+            iosSimulatorArm64Test.dependsOn(iosTest)
         }
 
         val jsMain by getting
@@ -188,9 +186,7 @@ kotlin {
 
     if (!runIosTests) {
         tasks.forEach {
-            if (it.name.contains("ios") && it.name.contains("test")) {
-                it.onlyIf { false }
-            }
+            if (it.name.contains("ios") && it.name.contains("test")) { it.enabled = false }
         }
     }
 }

--- a/firebase-auth/build.gradle.kts
+++ b/firebase-auth/build.gradle.kts
@@ -184,10 +184,7 @@ kotlin {
 
 if (project.property("firebase-auth.skipIosTests") == "true") {
     tasks.forEach {
-        if (it.name.contains("ios") && it.name.contains("test")) {
-            println("Skipping ${it.name}")
-            it.enabled = false
-        }
+        if (it.name.contains("ios", true) && it.name.contains("test", true)) { it.enabled = false }
     }
 }
 

--- a/firebase-auth/build.gradle.kts
+++ b/firebase-auth/build.gradle.kts
@@ -83,6 +83,7 @@ kotlin {
     val supportIosTarget = project.property("skipIosTarget") != "true"
     val runIosTests = project.property("firebase-auth.skipIosTests") != "true"
 
+    println("supportIosTarget: $supportIosTarget runIosTests $runIosTests")
     if (supportIosTarget) {
 
         fun nativeTargetConfig(): KotlinNativeTarget.() -> Unit = {

--- a/firebase-auth/build.gradle.kts
+++ b/firebase-auth/build.gradle.kts
@@ -81,7 +81,7 @@ kotlin {
     }
 
     val supportIosTarget = project.property("skipIosTarget") != "true"
-    val runIosTests = project.property("skipIosTests") != "true"
+    val runIosTests = project.property("firebase-auth.skipIosTests") != "true"
 
     if (supportIosTarget) {
 

--- a/firebase-auth/build.gradle.kts
+++ b/firebase-auth/build.gradle.kts
@@ -111,7 +111,6 @@ kotlin {
                     projectDir.resolve("src/nativeInterop/cinterop/Carthage/Build/$it.xcframework/${konanTarget.archVariant}")
                 }
             )
-
             binaries {
                 getTest("DEBUG").apply {
                     linkerOpts(nativeFrameworkPaths.map { "-F$it" })
@@ -185,6 +184,14 @@ kotlin {
         }
 
         val jsMain by getting
+    }
+
+    if (!runIosTests) {
+        tasks.forEach {
+            if (it.name.contains("ios") && it.name.contains("test")) {
+                it.onlyIf { false }
+            }
+        }
     }
 }
 

--- a/firebase-auth/src/androidAndroidTest/kotlin/dev/gitlive/firebase/auth/auth.kt
+++ b/firebase-auth/src/androidAndroidTest/kotlin/dev/gitlive/firebase/auth/auth.kt
@@ -13,14 +13,7 @@ actual val emulatorHost: String = "10.0.2.2"
 
 actual val context: Any = InstrumentationRegistry.getInstrumentation().targetContext
 
-actual val currentPlatform: Platform = Platform.Android
-
-actual fun runTest(skip: Boolean, test: suspend () -> Unit) = runBlocking {
-    if (skip) {
-        Log.w("Test", "Skip the test.")
-        return@runBlocking
-    }
-
+actual fun runTest(test: suspend () -> Unit) = runBlocking {
     test()
 }
 

--- a/firebase-auth/src/commonTest/kotlin/dev/gitlive/firebase/auth/auth.kt
+++ b/firebase-auth/src/commonTest/kotlin/dev/gitlive/firebase/auth/auth.kt
@@ -10,15 +10,9 @@ import kotlin.test.*
 
 expect val emulatorHost: String
 expect val context: Any
-expect fun runTest(skip: Boolean = false, test: suspend () -> Unit)
-expect val currentPlatform: Platform
-
-enum class Platform { Android, IOS, JS }
+expect fun runTest(test: suspend () -> Unit)
 
 class FirebaseAuthTest {
-
-    // Skip the tests on iOS simulator due keychain exceptions
-    private val skip = currentPlatform == Platform.IOS
 
     @BeforeTest
     fun initializeFirebase() {
@@ -41,14 +35,14 @@ class FirebaseAuthTest {
     }
 
     @Test
-    fun testSignInWithUsernameAndPassword() = runTest(skip) {
+    fun testSignInWithUsernameAndPassword() = runTest {
         val uid = getTestUid("test@test.com", "test123")
         val result = Firebase.auth.signInWithEmailAndPassword("test@test.com", "test123")
         assertEquals(uid, result.user!!.uid)
     }
 
     @Test
-    fun testCreateUserWithEmailAndPassword() = runTest(skip) {
+    fun testCreateUserWithEmailAndPassword() = runTest {
         val email = "test+${Random.nextInt(100000)}@test.com"
         val createResult = Firebase.auth.createUserWithEmailAndPassword(email, "test123")
         assertNotEquals(null, createResult.user?.uid)
@@ -63,7 +57,7 @@ class FirebaseAuthTest {
     }
 
     @Test
-    fun testFetchSignInMethods() = runTest(skip) {
+    fun testFetchSignInMethods() = runTest {
         val email = "test+${Random.nextInt(100000)}@test.com"
         var signInMethodResult = Firebase.auth.fetchSignInMethodsForEmail(email)
         assertEquals(emptyList(), signInMethodResult)
@@ -75,7 +69,7 @@ class FirebaseAuthTest {
     }
 
     @Test
-    fun testSendEmailVerification() = runTest(skip) {
+    fun testSendEmailVerification() = runTest {
         val email = "test+${Random.nextInt(100000)}@test.com"
         val createResult = Firebase.auth.createUserWithEmailAndPassword(email, "test123")
         assertNotEquals(null, createResult.user?.uid)
@@ -85,7 +79,7 @@ class FirebaseAuthTest {
     }
 
     @Test
-    fun sendPasswordResetEmail() = runTest(skip) {
+    fun sendPasswordResetEmail() = runTest {
         val email = "test+${Random.nextInt(100000)}@test.com"
         val createResult = Firebase.auth.createUserWithEmailAndPassword(email, "test123")
         assertNotEquals(null, createResult.user?.uid)
@@ -96,7 +90,7 @@ class FirebaseAuthTest {
     }
 
     @Test
-    fun testSignInWithCredential() = runTest(skip) {
+    fun testSignInWithCredential() = runTest {
         val uid = getTestUid("test@test.com", "test123")
         val credential = EmailAuthProvider.credential("test@test.com", "test123")
         val result = Firebase.auth.signInWithCredential(credential)

--- a/firebase-auth/src/iosTest/kotlin/dev/gitlive/firebase/auth/auth.kt
+++ b/firebase-auth/src/iosTest/kotlin/dev/gitlive/firebase/auth/auth.kt
@@ -11,14 +11,7 @@ actual val emulatorHost: String = "localhost"
 
 actual val context: Any = Unit
 
-actual val currentPlatform: Platform = Platform.IOS
-
-actual fun runTest(skip: Boolean, test: suspend () -> Unit) = runBlocking {
-    if (skip) {
-        NSLog("Skip the test.")
-        return@runBlocking
-    }
-
+actual fun runTest(test: suspend () -> Unit) = runBlocking {
     val testRun = MainScope().async { test() }
     while (testRun.isActive) {
         NSRunLoop.mainRunLoop.runMode(

--- a/firebase-auth/src/jsTest/kotlin/dev/gitlive/firebase/auth/auth.kt
+++ b/firebase-auth/src/jsTest/kotlin/dev/gitlive/firebase/auth/auth.kt
@@ -11,15 +11,8 @@ actual val emulatorHost: String = "localhost"
 
 actual val context: Any = Unit
 
-actual val currentPlatform: Platform = Platform.JS
-
-actual fun runTest(skip: Boolean, test: suspend () -> Unit) = GlobalScope
+actual fun runTest(test: suspend () -> Unit) = GlobalScope
     .promise {
-        if (skip) {
-            console.log("Skip the test.")
-            return@promise
-        }
-
         try {
             test()
         } catch (e: dynamic) {

--- a/firebase-common/build.gradle.kts
+++ b/firebase-common/build.gradle.kts
@@ -116,7 +116,7 @@ kotlin {
 
 if (project.property("firebase-common.skipIosTests") == "true") {
     tasks.forEach {
-        if (it.name.contains("ios") && it.name.contains("test")) { it.enabled = false }
+        if (it.name.contains("ios", true) && it.name.contains("test", true)) { it.enabled = false }
     }
 }
 

--- a/firebase-common/build.gradle.kts
+++ b/firebase-common/build.gradle.kts
@@ -47,7 +47,7 @@ kotlin {
     }
 
     val supportIosTarget = project.property("skipIosTarget") != "true"
-    val runIosTests = project.property("skipIosTests") != "true"
+    val runIosTests = project.property("firebase-common.skipIosTests") != "true"
 
     if (supportIosTarget) {
         ios()

--- a/firebase-common/build.gradle.kts
+++ b/firebase-common/build.gradle.kts
@@ -47,7 +47,6 @@ kotlin {
     }
 
     val supportIosTarget = project.property("skipIosTarget") != "true"
-    val runIosTests = project.property("firebase-common.skipIosTests") != "true"
 
     if (supportIosTarget) {
         ios()
@@ -102,11 +101,9 @@ kotlin {
             val iosSimulatorArm64Main by getting
             iosSimulatorArm64Main.dependsOn(iosMain)
 
-            if (runIosTests) {
-                val iosTest by sourceSets.getting
-                val iosSimulatorArm64Test by sourceSets.getting
-                iosSimulatorArm64Test.dependsOn(iosTest)
-            }
+            val iosTest by sourceSets.getting
+            val iosSimulatorArm64Test by sourceSets.getting
+            iosSimulatorArm64Test.dependsOn(iosTest)
         }
 
         val jsMain by getting {
@@ -114,6 +111,12 @@ kotlin {
                 api(npm("firebase", "8.7.1"))
             }
         }
+    }
+}
+
+if (project.property("firebase-common.skipIosTests") == "true") {
+    tasks.forEach {
+        if (it.name.contains("ios") && it.name.contains("test")) { it.enabled = false }
     }
 }
 

--- a/firebase-common/build.gradle.kts
+++ b/firebase-common/build.gradle.kts
@@ -46,8 +46,13 @@ kotlin {
         publishAllLibraryVariants()
     }
 
-    ios()
-    iosSimulatorArm64()
+    val supportIosTarget = project.property("skipIosTarget") != "true"
+    val runIosTests = project.property("skipIosTests") != "true"
+
+    if (supportIosTarget) {
+        ios()
+        iosSimulatorArm64()
+    }
 
     js {
         useCommonJs()
@@ -92,13 +97,17 @@ kotlin {
             }
         }
 
-        val iosMain by getting
-        val iosSimulatorArm64Main by getting
-        iosSimulatorArm64Main.dependsOn(iosMain)
+        if (supportIosTarget) {
+            val iosMain by getting
+            val iosSimulatorArm64Main by getting
+            iosSimulatorArm64Main.dependsOn(iosMain)
 
-        val iosTest by sourceSets.getting
-        val iosSimulatorArm64Test by sourceSets.getting
-        iosSimulatorArm64Test.dependsOn(iosTest)
+            if (runIosTests) {
+                val iosTest by sourceSets.getting
+                val iosSimulatorArm64Test by sourceSets.getting
+                iosSimulatorArm64Test.dependsOn(iosTest)
+            }
+        }
 
         val jsMain by getting {
             dependencies {

--- a/firebase-config/build.gradle.kts
+++ b/firebase-config/build.gradle.kts
@@ -162,7 +162,7 @@ kotlin {
 
 if (project.property("firebase-config.skipIosTests") == "true") {
     tasks.forEach {
-        if (it.name.contains("ios") && it.name.contains("test")) { it.enabled = false }
+        if (it.name.contains("ios", true) && it.name.contains("test", true)) { it.enabled = false }
     }
 }
 

--- a/firebase-config/build.gradle.kts
+++ b/firebase-config/build.gradle.kts
@@ -69,45 +69,50 @@ kotlin {
         publishAllLibraryVariants()
     }
 
-    fun nativeTargetConfig(): KotlinNativeTarget.() -> Unit = {
-        val nativeFrameworkPaths = listOf(
-            "FirebaseCore",
-            "FirebaseCoreDiagnostics",
-            "FirebaseAnalytics",
-            "GoogleAppMeasurement",
-            "FirebaseInstallations",
-            "GoogleDataTransport",
-            "GoogleUtilities",
-            "PromisesObjC",
-            "nanopb"
-        ).map {
-            rootProject.project("firebase-app").projectDir.resolve("src/nativeInterop/cinterop/Carthage/Build/$it.xcframework/${konanTarget.archVariant}")
-        }.plus(
-            listOf(
-                "FirebaseABTesting",
-                "FirebaseRemoteConfig"
+    val supportIosTarget = project.property("skipIosTarget") != "true"
+    val runIosTests = project.property("skipIosTests") != "true"
+
+    if (supportIosTarget) {
+        fun nativeTargetConfig(): KotlinNativeTarget.() -> Unit = {
+            val nativeFrameworkPaths = listOf(
+                "FirebaseCore",
+                "FirebaseCoreDiagnostics",
+                "FirebaseAnalytics",
+                "GoogleAppMeasurement",
+                "FirebaseInstallations",
+                "GoogleDataTransport",
+                "GoogleUtilities",
+                "PromisesObjC",
+                "nanopb"
             ).map {
-                projectDir.resolve("src/nativeInterop/cinterop/Carthage/Build/$it.xcframework/${konanTarget.archVariant}")
-            }
-        )
+                rootProject.project("firebase-app").projectDir.resolve("src/nativeInterop/cinterop/Carthage/Build/$it.xcframework/${konanTarget.archVariant}")
+            }.plus(
+                listOf(
+                    "FirebaseABTesting",
+                    "FirebaseRemoteConfig"
+                ).map {
+                    projectDir.resolve("src/nativeInterop/cinterop/Carthage/Build/$it.xcframework/${konanTarget.archVariant}")
+                }
+            )
 
-        binaries {
-            getTest("DEBUG").apply {
-                linkerOpts(nativeFrameworkPaths.map { "-F$it" })
-                linkerOpts("-ObjC")
+            binaries {
+                getTest("DEBUG").apply {
+                    linkerOpts(nativeFrameworkPaths.map { "-F$it" })
+                    linkerOpts("-ObjC")
+                }
+            }
+
+            compilations.getByName("main") {
+                cinterops.create("FirebaseRemoteConfig") {
+                    compilerOpts(nativeFrameworkPaths.map { "-F$it" })
+                    extraOpts("-verbose")
+                }
             }
         }
 
-        compilations.getByName("main") {
-            cinterops.create("FirebaseRemoteConfig") {
-                compilerOpts(nativeFrameworkPaths.map { "-F$it" })
-                extraOpts("-verbose")
-            }
-        }
+        ios(configure = nativeTargetConfig())
+        iosSimulatorArm64(configure = nativeTargetConfig())
     }
-
-    ios(configure = nativeTargetConfig())
-    iosSimulatorArm64(configure = nativeTargetConfig())
 
     js {
         useCommonJs()
@@ -143,13 +148,17 @@ kotlin {
             }
         }
 
-        val iosMain by getting
-        val iosSimulatorArm64Main by getting
-        iosSimulatorArm64Main.dependsOn(iosMain)
+        if (supportIosTarget) {
+            val iosMain by getting
+            val iosSimulatorArm64Main by getting
+            iosSimulatorArm64Main.dependsOn(iosMain)
 
-        val iosTest by sourceSets.getting
-        val iosSimulatorArm64Test by sourceSets.getting
-        iosSimulatorArm64Test.dependsOn(iosTest)
+            if (runIosTests) {
+                val iosTest by sourceSets.getting
+                val iosSimulatorArm64Test by sourceSets.getting
+                iosSimulatorArm64Test.dependsOn(iosTest)
+            }
+        }
 
         val jsMain by getting
     }

--- a/firebase-config/build.gradle.kts
+++ b/firebase-config/build.gradle.kts
@@ -70,7 +70,7 @@ kotlin {
     }
 
     val supportIosTarget = project.property("skipIosTarget") != "true"
-    val runIosTests = project.property("skipIosTests") != "true"
+    val runIosTests = project.property("firebase-config.skipIosTests") != "true"
 
     if (supportIosTarget) {
         fun nativeTargetConfig(): KotlinNativeTarget.() -> Unit = {

--- a/firebase-config/build.gradle.kts
+++ b/firebase-config/build.gradle.kts
@@ -70,8 +70,6 @@ kotlin {
     }
 
     val supportIosTarget = project.property("skipIosTarget") != "true"
-    val runIosTests = project.property("firebase-config.skipIosTests") != "true"
-
     if (supportIosTarget) {
         fun nativeTargetConfig(): KotlinNativeTarget.() -> Unit = {
             val nativeFrameworkPaths = listOf(
@@ -153,14 +151,18 @@ kotlin {
             val iosSimulatorArm64Main by getting
             iosSimulatorArm64Main.dependsOn(iosMain)
 
-            if (runIosTests) {
-                val iosTest by sourceSets.getting
-                val iosSimulatorArm64Test by sourceSets.getting
-                iosSimulatorArm64Test.dependsOn(iosTest)
-            }
+            val iosTest by sourceSets.getting
+            val iosSimulatorArm64Test by sourceSets.getting
+            iosSimulatorArm64Test.dependsOn(iosTest)
         }
 
         val jsMain by getting
+    }
+}
+
+if (project.property("firebase-config.skipIosTests") == "true") {
+    tasks.forEach {
+        if (it.name.contains("ios") && it.name.contains("test")) { it.enabled = false }
     }
 }
 

--- a/firebase-database/build.gradle.kts
+++ b/firebase-database/build.gradle.kts
@@ -56,49 +56,54 @@ kotlin {
         publishAllLibraryVariants()
     }
 
-    fun nativeTargetConfig(): KotlinNativeTarget.() -> Unit = {
-        val nativeFrameworkPaths = listOf(
-            rootProject.project("firebase-app").projectDir.resolve("src/nativeInterop/cinterop/Carthage/Build/iOS")
-        ).plus(
-            listOf(
-                "FirebaseAnalytics",
-                "FirebaseCore",
-                "FirebaseCoreDiagnostics",
-                "FirebaseInstallations",
-                "GoogleAppMeasurement",
-                "GoogleDataTransport",
-                "GoogleUtilities",
-                "nanopb",
-                "PromisesObjC"
-            ).map {
-                rootProject.project("firebase-app").projectDir.resolve("src/nativeInterop/cinterop/Carthage/Build/$it.xcframework/${konanTarget.archVariant}")
-            }
-        ).plus(
-            listOf(
-                "FirebaseDatabase",
-                "leveldb-library"
-            ).map {
-                projectDir.resolve("src/nativeInterop/cinterop/Carthage/Build/$it.xcframework/${konanTarget.archVariant}")
-            }
-        )
+    val supportIosTarget = project.property("skipIosTarget") != "true"
+    val runIosTests = project.property("skipIosTests") != "true"
 
-        binaries {
-            getTest("DEBUG").apply {
-                linkerOpts(nativeFrameworkPaths.map { "-F$it" })
-                linkerOpts("-ObjC")
+    if (supportIosTarget) {
+        fun nativeTargetConfig(): KotlinNativeTarget.() -> Unit = {
+            val nativeFrameworkPaths = listOf(
+                rootProject.project("firebase-app").projectDir.resolve("src/nativeInterop/cinterop/Carthage/Build/iOS")
+            ).plus(
+                listOf(
+                    "FirebaseAnalytics",
+                    "FirebaseCore",
+                    "FirebaseCoreDiagnostics",
+                    "FirebaseInstallations",
+                    "GoogleAppMeasurement",
+                    "GoogleDataTransport",
+                    "GoogleUtilities",
+                    "nanopb",
+                    "PromisesObjC"
+                ).map {
+                    rootProject.project("firebase-app").projectDir.resolve("src/nativeInterop/cinterop/Carthage/Build/$it.xcframework/${konanTarget.archVariant}")
+                }
+            ).plus(
+                listOf(
+                    "FirebaseDatabase",
+                    "leveldb-library"
+                ).map {
+                    projectDir.resolve("src/nativeInterop/cinterop/Carthage/Build/$it.xcframework/${konanTarget.archVariant}")
+                }
+            )
+
+            binaries {
+                getTest("DEBUG").apply {
+                    linkerOpts(nativeFrameworkPaths.map { "-F$it" })
+                    linkerOpts("-ObjC")
+                }
+            }
+
+            compilations.getByName("main") {
+                cinterops.create("FirebaseDatabase") {
+                    compilerOpts(nativeFrameworkPaths.map { "-F$it" })
+                    extraOpts("-verbose")
+                }
             }
         }
 
-        compilations.getByName("main") {
-            cinterops.create("FirebaseDatabase") {
-                compilerOpts(nativeFrameworkPaths.map { "-F$it" })
-                extraOpts("-verbose")
-            }
-        }
+        ios(configure = nativeTargetConfig())
+        iosSimulatorArm64(configure = nativeTargetConfig())
     }
-
-    ios(configure = nativeTargetConfig())
-    iosSimulatorArm64(configure = nativeTargetConfig())
 
     js {
         useCommonJs()
@@ -143,13 +148,17 @@ kotlin {
             }
         }
 
-        val iosMain by getting
-        val iosSimulatorArm64Main by getting
-        iosSimulatorArm64Main.dependsOn(iosMain)
+        if (supportIosTarget) {
+            val iosMain by getting
+            val iosSimulatorArm64Main by getting
+            iosSimulatorArm64Main.dependsOn(iosMain)
 
-        val iosTest by sourceSets.getting
-        val iosSimulatorArm64Test by sourceSets.getting
-        iosSimulatorArm64Test.dependsOn(iosTest)
+            if (runIosTests) {
+                val iosTest by sourceSets.getting
+                val iosSimulatorArm64Test by sourceSets.getting
+                iosSimulatorArm64Test.dependsOn(iosTest)
+            }
+        }
 
         val jsMain by getting
     }

--- a/firebase-database/build.gradle.kts
+++ b/firebase-database/build.gradle.kts
@@ -57,8 +57,6 @@ kotlin {
     }
 
     val supportIosTarget = project.property("skipIosTarget") != "true"
-    val runIosTests = project.property("firebase-database.skipIosTests") != "true"
-
     if (supportIosTarget) {
         fun nativeTargetConfig(): KotlinNativeTarget.() -> Unit = {
             val nativeFrameworkPaths = listOf(
@@ -153,14 +151,18 @@ kotlin {
             val iosSimulatorArm64Main by getting
             iosSimulatorArm64Main.dependsOn(iosMain)
 
-            if (runIosTests) {
-                val iosTest by sourceSets.getting
-                val iosSimulatorArm64Test by sourceSets.getting
-                iosSimulatorArm64Test.dependsOn(iosTest)
-            }
+            val iosTest by sourceSets.getting
+            val iosSimulatorArm64Test by sourceSets.getting
+            iosSimulatorArm64Test.dependsOn(iosTest)
         }
 
         val jsMain by getting
+    }
+}
+
+if (project.property("firebase-skipIosTests.skipIosTests") == "true") {
+    tasks.forEach {
+        if (it.name.contains("ios") && it.name.contains("test")) { it.enabled = false }
     }
 }
 

--- a/firebase-database/build.gradle.kts
+++ b/firebase-database/build.gradle.kts
@@ -57,7 +57,7 @@ kotlin {
     }
 
     val supportIosTarget = project.property("skipIosTarget") != "true"
-    val runIosTests = project.property("skipIosTests") != "true"
+    val runIosTests = project.property("firebase-database.skipIosTests") != "true"
 
     if (supportIosTarget) {
         fun nativeTargetConfig(): KotlinNativeTarget.() -> Unit = {

--- a/firebase-database/build.gradle.kts
+++ b/firebase-database/build.gradle.kts
@@ -162,7 +162,7 @@ kotlin {
 
 if (project.property("firebase-skipIosTests.skipIosTests") == "true") {
     tasks.forEach {
-        if (it.name.contains("ios") && it.name.contains("test")) { it.enabled = false }
+        if (it.name.contains("ios", true) && it.name.contains("test", true)) { it.enabled = false }
     }
 }
 

--- a/firebase-database/build.gradle.kts
+++ b/firebase-database/build.gradle.kts
@@ -160,7 +160,7 @@ kotlin {
     }
 }
 
-if (project.property("firebase-skipIosTests.skipIosTests") == "true") {
+if (project.property("firebase-database.skipIosTests") == "true") {
     tasks.forEach {
         if (it.name.contains("ios", true) && it.name.contains("test", true)) { it.enabled = false }
     }

--- a/firebase-firestore/build.gradle.kts
+++ b/firebase-firestore/build.gradle.kts
@@ -60,7 +60,7 @@ kotlin {
     }
 
     val supportIosTarget = project.property("skipIosTarget") != "true"
-    val runIosTests = project.property("skipIosTests") != "true"
+    val runIosTests = project.property("firebase-firestore.skipIosTests") != "true"
 
     if (supportIosTarget) {
         fun nativeTargetConfig(): KotlinNativeTarget.() -> Unit = {

--- a/firebase-firestore/build.gradle.kts
+++ b/firebase-firestore/build.gradle.kts
@@ -60,8 +60,6 @@ kotlin {
     }
 
     val supportIosTarget = project.property("skipIosTarget") != "true"
-    val runIosTests = project.property("firebase-firestore.skipIosTests") != "true"
-
     if (supportIosTarget) {
         fun nativeTargetConfig(): KotlinNativeTarget.() -> Unit = {
             val nativeFrameworkPaths = listOf(
@@ -159,16 +157,21 @@ kotlin {
             val iosSimulatorArm64Main by getting
             iosSimulatorArm64Main.dependsOn(iosMain)
 
-            if (runIosTests) {
-                val iosTest by sourceSets.getting
-                val iosSimulatorArm64Test by sourceSets.getting
-                iosSimulatorArm64Test.dependsOn(iosTest)
-            }
+            val iosTest by sourceSets.getting
+            val iosSimulatorArm64Test by sourceSets.getting
+            iosSimulatorArm64Test.dependsOn(iosTest)
         }
 
         val jsMain by getting
     }
 }
+
+if (project.property("firebase-firestore.skipIosTests") == "true") {
+    tasks.forEach {
+        if (it.name.contains("ios") && it.name.contains("test")) { it.enabled = false }
+    }
+}
+
 signing {
     val signingKey: String? by project
     val signingPassword: String? by project

--- a/firebase-firestore/build.gradle.kts
+++ b/firebase-firestore/build.gradle.kts
@@ -168,7 +168,7 @@ kotlin {
 
 if (project.property("firebase-firestore.skipIosTests") == "true") {
     tasks.forEach {
-        if (it.name.contains("ios") && it.name.contains("test")) { it.enabled = false }
+        if (it.name.contains("ios", true) && it.name.contains("test", true)) { it.enabled = false }
     }
 }
 

--- a/firebase-firestore/build.gradle.kts
+++ b/firebase-firestore/build.gradle.kts
@@ -59,53 +59,58 @@ kotlin {
         publishAllLibraryVariants()
     }
 
-    fun nativeTargetConfig(): KotlinNativeTarget.() -> Unit = {
-        val nativeFrameworkPaths = listOf(
-            rootProject.project("firebase-app").projectDir.resolve("src/nativeInterop/cinterop/Carthage/Build/iOS")
-        ).plus(
-            listOf(
-                "FirebaseAnalytics",
-                "FirebaseCore",
-                "FirebaseCoreDiagnostics",
-                "FirebaseInstallations",
-                "GoogleAppMeasurement",
-                "GoogleDataTransport",
-                "GoogleUtilities",
-                "nanopb",
-                "PromisesObjC"
-            ).map {
-                rootProject.project("firebase-app").projectDir.resolve("src/nativeInterop/cinterop/Carthage/Build/$it.xcframework/${konanTarget.archVariant}")
-            }
-        ).plus(
-            listOf(
-                "abseil",
-                "BoringSSL-GRPC",
-                "FirebaseFirestore",
-                "gRPC-Core",
-                "gRPC-C++",
-                "leveldb-library"
-            ).map {
-                projectDir.resolve("src/nativeInterop/cinterop/Carthage/Build/$it.xcframework/${konanTarget.archVariant}")
-            }
-        )
+    val supportIosTarget = project.property("skipIosTarget") != "true"
+    val runIosTests = project.property("skipIosTests") != "true"
 
-        binaries {
-            getTest("DEBUG").apply {
-                linkerOpts(nativeFrameworkPaths.map { "-F$it" })
-                linkerOpts("-ObjC")
+    if (supportIosTarget) {
+        fun nativeTargetConfig(): KotlinNativeTarget.() -> Unit = {
+            val nativeFrameworkPaths = listOf(
+                rootProject.project("firebase-app").projectDir.resolve("src/nativeInterop/cinterop/Carthage/Build/iOS")
+            ).plus(
+                listOf(
+                    "FirebaseAnalytics",
+                    "FirebaseCore",
+                    "FirebaseCoreDiagnostics",
+                    "FirebaseInstallations",
+                    "GoogleAppMeasurement",
+                    "GoogleDataTransport",
+                    "GoogleUtilities",
+                    "nanopb",
+                    "PromisesObjC"
+                ).map {
+                    rootProject.project("firebase-app").projectDir.resolve("src/nativeInterop/cinterop/Carthage/Build/$it.xcframework/${konanTarget.archVariant}")
+                }
+            ).plus(
+                listOf(
+                    "abseil",
+                    "BoringSSL-GRPC",
+                    "FirebaseFirestore",
+                    "gRPC-Core",
+                    "gRPC-C++",
+                    "leveldb-library"
+                ).map {
+                    projectDir.resolve("src/nativeInterop/cinterop/Carthage/Build/$it.xcframework/${konanTarget.archVariant}")
+                }
+            )
+
+            binaries {
+                getTest("DEBUG").apply {
+                    linkerOpts(nativeFrameworkPaths.map { "-F$it" })
+                    linkerOpts("-ObjC")
+                }
+            }
+
+            compilations.getByName("main") {
+                cinterops.create("FirebaseFirestore") {
+                    compilerOpts(nativeFrameworkPaths.map { "-F$it" })
+                    extraOpts("-verbose")
+                }
             }
         }
 
-        compilations.getByName("main") {
-            cinterops.create("FirebaseFirestore") {
-                compilerOpts(nativeFrameworkPaths.map { "-F$it" })
-                extraOpts("-verbose")
-            }
-        }
+        ios(configure = nativeTargetConfig())
+        iosSimulatorArm64(configure = nativeTargetConfig())
     }
-
-    ios(configure = nativeTargetConfig())
-    iosSimulatorArm64(configure = nativeTargetConfig())
 
     js {
         useCommonJs()
@@ -149,13 +154,17 @@ kotlin {
             }
         }
 
-        val iosMain by getting
-        val iosSimulatorArm64Main by getting
-        iosSimulatorArm64Main.dependsOn(iosMain)
+        if (supportIosTarget) {
+            val iosMain by getting
+            val iosSimulatorArm64Main by getting
+            iosSimulatorArm64Main.dependsOn(iosMain)
 
-        val iosTest by sourceSets.getting
-        val iosSimulatorArm64Test by sourceSets.getting
-        iosSimulatorArm64Test.dependsOn(iosTest)
+            if (runIosTests) {
+                val iosTest by sourceSets.getting
+                val iosSimulatorArm64Test by sourceSets.getting
+                iosSimulatorArm64Test.dependsOn(iosTest)
+            }
+        }
 
         val jsMain by getting
     }

--- a/firebase-functions/build.gradle.kts
+++ b/firebase-functions/build.gradle.kts
@@ -156,7 +156,7 @@ kotlin {
 
 if (project.property("firebase-functions.skipIosTests") == "true") {
     tasks.forEach {
-        if (it.name.contains("ios") && it.name.contains("test")) { it.enabled = false }
+        if (it.name.contains("ios", true) && it.name.contains("test", true)) { it.enabled = false }
     }
 }
 

--- a/firebase-functions/build.gradle.kts
+++ b/firebase-functions/build.gradle.kts
@@ -52,8 +52,6 @@ kotlin {
     }
 
     val supportIosTarget = project.property("skipIosTarget") != "true"
-    val runIosTests = project.property("firebase-functions.skipIosTests") != "true"
-
     if (supportIosTarget) {
         fun nativeTargetConfig(): KotlinNativeTarget.() -> Unit = {
             val nativeFrameworkPaths = listOf(
@@ -147,14 +145,18 @@ kotlin {
             val iosSimulatorArm64Main by getting
             iosSimulatorArm64Main.dependsOn(iosMain)
 
-            if (runIosTests) {
-                val iosTest by sourceSets.getting
-                val iosSimulatorArm64Test by sourceSets.getting
-                iosSimulatorArm64Test.dependsOn(iosTest)
-            }
+            val iosTest by sourceSets.getting
+            val iosSimulatorArm64Test by sourceSets.getting
+            iosSimulatorArm64Test.dependsOn(iosTest)
         }
 
         val jsMain by getting
+    }
+}
+
+if (project.property("firebase-functions.skipIosTests") == "true") {
+    tasks.forEach {
+        if (it.name.contains("ios") && it.name.contains("test")) { it.enabled = false }
     }
 }
 

--- a/firebase-functions/build.gradle.kts
+++ b/firebase-functions/build.gradle.kts
@@ -51,49 +51,54 @@ kotlin {
         publishAllLibraryVariants()
     }
 
-    fun nativeTargetConfig(): KotlinNativeTarget.() -> Unit = {
-        val nativeFrameworkPaths = listOf(
-            rootProject.project("firebase-app").projectDir.resolve("src/nativeInterop/cinterop/Carthage/Build/iOS")
-        ).plus(
-            listOf(
-                "FirebaseAnalytics",
-                "FirebaseCore",
-                "FirebaseCoreDiagnostics",
-                "FirebaseInstallations",
-                "GoogleAppMeasurement",
-                "GoogleDataTransport",
-                "GoogleUtilities",
-                "nanopb",
-                "PromisesObjC"
-            ).map {
-                rootProject.project("firebase-app").projectDir.resolve("src/nativeInterop/cinterop/Carthage/Build/$it.xcframework/${konanTarget.archVariant}")
-            }
-        ).plus(
-            listOf(
-                "FirebaseFunctions",
-                "GTMSessionFetcher"
-            ).map {
-                projectDir.resolve("src/nativeInterop/cinterop/Carthage/Build/$it.xcframework/${konanTarget.archVariant}")
-            }
-        )
+    val supportIosTarget = project.property("skipIosTarget") != "true"
+    val runIosTests = project.property("skipIosTests") != "true"
 
-        binaries {
-            getTest("DEBUG").apply {
-                linkerOpts(nativeFrameworkPaths.map { "-F$it" })
-                linkerOpts("-ObjC")
+    if (supportIosTarget) {
+        fun nativeTargetConfig(): KotlinNativeTarget.() -> Unit = {
+            val nativeFrameworkPaths = listOf(
+                rootProject.project("firebase-app").projectDir.resolve("src/nativeInterop/cinterop/Carthage/Build/iOS")
+            ).plus(
+                listOf(
+                    "FirebaseAnalytics",
+                    "FirebaseCore",
+                    "FirebaseCoreDiagnostics",
+                    "FirebaseInstallations",
+                    "GoogleAppMeasurement",
+                    "GoogleDataTransport",
+                    "GoogleUtilities",
+                    "nanopb",
+                    "PromisesObjC"
+                ).map {
+                    rootProject.project("firebase-app").projectDir.resolve("src/nativeInterop/cinterop/Carthage/Build/$it.xcframework/${konanTarget.archVariant}")
+                }
+            ).plus(
+                listOf(
+                    "FirebaseFunctions",
+                    "GTMSessionFetcher"
+                ).map {
+                    projectDir.resolve("src/nativeInterop/cinterop/Carthage/Build/$it.xcframework/${konanTarget.archVariant}")
+                }
+            )
+
+            binaries {
+                getTest("DEBUG").apply {
+                    linkerOpts(nativeFrameworkPaths.map { "-F$it" })
+                    linkerOpts("-ObjC")
+                }
+            }
+
+            compilations.getByName("main") {
+                cinterops.create("FirebaseFunctions") {
+                    compilerOpts(nativeFrameworkPaths.map { "-F$it" })
+                    extraOpts("-verbose")
+                }
             }
         }
 
-        compilations.getByName("main") {
-            cinterops.create("FirebaseFunctions") {
-                compilerOpts(nativeFrameworkPaths.map { "-F$it" })
-                extraOpts("-verbose")
-            }
-        }
+        ios(configure = nativeTargetConfig())
+        iosSimulatorArm64(configure = nativeTargetConfig())
     }
-
-    ios(configure = nativeTargetConfig())
-    iosSimulatorArm64(configure = nativeTargetConfig())
 
     js {
         useCommonJs()
@@ -137,13 +142,17 @@ kotlin {
             }
         }
 
-        val iosMain by getting
-        val iosSimulatorArm64Main by getting
-        iosSimulatorArm64Main.dependsOn(iosMain)
+        if (supportIosTarget) {
+            val iosMain by getting
+            val iosSimulatorArm64Main by getting
+            iosSimulatorArm64Main.dependsOn(iosMain)
 
-        val iosTest by sourceSets.getting
-        val iosSimulatorArm64Test by sourceSets.getting
-        iosSimulatorArm64Test.dependsOn(iosTest)
+            if (runIosTests) {
+                val iosTest by sourceSets.getting
+                val iosSimulatorArm64Test by sourceSets.getting
+                iosSimulatorArm64Test.dependsOn(iosTest)
+            }
+        }
 
         val jsMain by getting
     }

--- a/firebase-functions/build.gradle.kts
+++ b/firebase-functions/build.gradle.kts
@@ -52,7 +52,7 @@ kotlin {
     }
 
     val supportIosTarget = project.property("skipIosTarget") != "true"
-    val runIosTests = project.property("skipIosTests") != "true"
+    val runIosTests = project.property("firebase-functions.skipIosTests") != "true"
 
     if (supportIosTarget) {
         fun nativeTargetConfig(): KotlinNativeTarget.() -> Unit = {

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,8 +17,16 @@ org.gradle.parallel=true
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 testOptions.unitTests.isIncludeAndroidResources=true
 
+# Set to true to skip tests and even compilation of the iOS target.
 skipIosTarget=false
-skipIosTests=false
+# Skip iOS Tests
+firebase-app.skipIosTests=false
+firebase-auth.skipIosTests=false
+firebase-common.skipIosTests=false
+firebase-database.skipIosTests=false
+firebase-firestore.skipIosTests=false
+firebase-functions.skipIosTests=false
+firebase-config.skipIosTests=false
 
 # Versions:
 firebase-app.version=1.4.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,6 +17,9 @@ org.gradle.parallel=true
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 testOptions.unitTests.isIncludeAndroidResources=true
 
+skipIosTarget=false
+skipIosTests=false
+
 # Versions:
 firebase-app.version=1.4.2
 firebase-auth.version=1.4.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ testOptions.unitTests.isIncludeAndroidResources=true
 skipIosTarget=false
 # Skip iOS Tests
 firebase-app.skipIosTests=false
-firebase-auth.skipIosTests=false
+firebase-auth.skipIosTests=true
 firebase-common.skipIosTests=false
 firebase-database.skipIosTests=false
 firebase-firestore.skipIosTests=false


### PR DESCRIPTION
Properties can be easily overridden via environment variable or just by manually editing the gradle.properties file.
Fixes #209