### PR TITLE
allow to get database root reference

### DIFF
--- a/firebase-database/src/androidMain/kotlin/dev/gitlive/firebase/database/database.kt
+++ b/firebase-database/src/androidMain/kotlin/dev/gitlive/firebase/database/database.kt
@@ -67,6 +67,9 @@ actual class FirebaseDatabase internal constructor(val android: com.google.fireb
     actual fun reference(path: String) =
         DatabaseReference(android.getReference(path), persistenceEnabled)
 
+    actual fun reference() =
+        DatabaseReference(android.reference, persistenceEnabled)
+
     actual fun setPersistenceEnabled(enabled: Boolean) =
         android.setPersistenceEnabled(enabled).also { persistenceEnabled = enabled }
 

--- a/firebase-database/src/commonMain/kotlin/dev/gitlive/firebase/database/database.kt
+++ b/firebase-database/src/commonMain/kotlin/dev/gitlive/firebase/database/database.kt
@@ -25,6 +25,7 @@ expect fun Firebase.database(app: FirebaseApp, url: String): FirebaseDatabase
 
 expect class FirebaseDatabase {
     fun reference(path: String): DatabaseReference
+    fun reference(): DatabaseReference
     fun setPersistenceEnabled(enabled: Boolean)
     fun setLoggingEnabled(enabled: Boolean)
     fun useEmulator(host: String, port: Int)

--- a/firebase-database/src/iosMain/kotlin/dev/gitlive/firebase/database/database.kt
+++ b/firebase-database/src/iosMain/kotlin/dev/gitlive/firebase/database/database.kt
@@ -51,6 +51,9 @@ actual class FirebaseDatabase internal constructor(val ios: FIRDatabase) {
     actual fun reference(path: String) =
         DatabaseReference(ios.referenceWithPath(path), ios.persistenceEnabled)
 
+    actual fun reference() =
+        DatabaseReference(ios.reference(), ios.persistenceEnabled)
+
     actual fun setPersistenceEnabled(enabled: Boolean) {
         ios.persistenceEnabled = enabled
     }

--- a/firebase-database/src/jsMain/kotlin/dev/gitlive/firebase/database/database.kt
+++ b/firebase-database/src/jsMain/kotlin/dev/gitlive/firebase/database/database.kt
@@ -37,6 +37,7 @@ actual fun Firebase.database(app: FirebaseApp, url: String) =
 
 actual class FirebaseDatabase internal constructor(val js: firebase.database.Database) {
     actual fun reference(path: String) = rethrow { DatabaseReference(js.ref(path)) }
+    actual fun reference() = rethrow { DatabaseReference(js.ref()) }
     actual fun setPersistenceEnabled(enabled: Boolean) {}
     actual fun setLoggingEnabled(enabled: Boolean) = rethrow { firebase.database.enableLogging(enabled) }
     actual fun useEmulator(host: String, port: Int) = rethrow { js.useEmulator(host, port) }


### PR DESCRIPTION
This PR is to allow to get access to the root's reference of a Realtime Database.
Just calling `Firebase.database.reference("")` is not possible because there's an empty string validation in iOS (not in android). 
A proper way to get this reference is now possible with `Firebase.database.reference()`