### PR TITLE
[Functions] Fix iOS exception message

### DIFF
--- a/firebase-functions/src/iosMain/kotlin/dev/gitlive/firebase/functions/functions.kt
+++ b/firebase-functions/src/iosMain/kotlin/dev/gitlive/firebase/functions/functions.kt
@@ -63,7 +63,7 @@ suspend inline fun <T> T.await(function: T.(callback: (NSError?) -> Unit) -> Uni
         if(error == null) {
             job.complete(Unit)
         } else {
-            job.completeExceptionally(FirebaseFunctionsException(error.toString()))
+            job.completeExceptionally(FirebaseFunctionsException(error.localizedDescription))
         }
     }
     job.await()
@@ -75,7 +75,7 @@ suspend inline fun <T, reified R> T.awaitResult(function: T.(callback: (R?, NSEr
         if(error == null) {
             job.complete(result)
         } else {
-            job.completeExceptionally(FirebaseFunctionsException(error.toString()))
+            job.completeExceptionally(FirebaseFunctionsException(error.localizedDescription))
         }
     }
     return job.await() as R


### PR DESCRIPTION
When an error is returned in a cloud function (e.g. `HttpsError("internal", "This is the error message")`), the `actual` iOS implementation incorrectly propagates the message to `FirebaseFunctionsException`. 

Rather than set `message = message`, it sets `message = theNSError.toString()` which produces an Objective-C string representation of the error. This prevents us from being able to parse that field reliably, since it is in an unstructured format and is inconsistent between Android and iOS.

This change brings iOS in parity with Android, where the exception's `message` matches that of the error returned by Firebase.
e.g. `message = "This is the error message"`