### PR TITLE
Failing sealed class list encoding / decoding tests

### DIFF
--- a/firebase-common/src/androidMain/kotlin/dev/gitlive/firebase/_decoders.kt
+++ b/firebase-common/src/androidMain/kotlin/dev/gitlive/firebase/_decoders.kt
@@ -11,7 +11,14 @@ import kotlinx.serialization.descriptors.StructureKind
 
 actual fun FirebaseDecoder.structureDecoder(descriptor: SerialDescriptor): CompositeDecoder = when(descriptor.kind) {
         StructureKind.CLASS, StructureKind.OBJECT, PolymorphicKind.SEALED -> (value as Map<*, *>).let { map ->
-            FirebaseClassDecoder(map.size, { map.containsKey(it) }) { desc, index -> map[desc.getElementName(index)] }
+            FirebaseClassDecoder(map.size, { map.containsKey(it) }) { desc, index ->
+                val elementName = desc.getElementName(index)
+                if (desc.kind is PolymorphicKind && elementName == "value") {
+                    map
+                } else {
+                    map[desc.getElementName(index)]
+                }
+            }
         }
         StructureKind.LIST -> (value as List<*>).let {
             FirebaseCompositeDecoder(it.size) { _, index -> it[index] }

--- a/firebase-common/src/commonTest/kotlin/dev/gitlive/firebase/EncodersTest.kt
+++ b/firebase-common/src/commonTest/kotlin/dev/gitlive/firebase/EncodersTest.kt
@@ -90,7 +90,7 @@ class EncodersTest {
             TestData.serializer(),
             encoded
         )
-        nativeAssertEquals(target, decoded)
+        assertEquals(target, decoded)
     }
 
     @Test
@@ -106,6 +106,6 @@ class EncodersTest {
             TestSealedList.serializer(),
             encoded
         )
-        nativeAssertEquals(target, decoded)
+        assertEquals(target, decoded)
     }
 }

--- a/firebase-common/src/commonTest/kotlin/dev/gitlive/firebase/EncodersTest.kt
+++ b/firebase-common/src/commonTest/kotlin/dev/gitlive/firebase/EncodersTest.kt
@@ -79,33 +79,60 @@ class EncodersTest {
     }
 
     @Test
-    fun encodeDecodeSealedClass() {
-        val target = TestData(mapOf("key" to "value"), true)
-        val encoded = encode<TestData>(
-            TestData.serializer(),
-            target,
-            shouldEncodeElementDefault = false
+    fun encodeSealedClassList() {
+        val toEncode = TestSealedList(
+            list = listOf(
+                TestSealed.ChildClass(
+                    map = mapOf("key" to "value"),
+                    bool = false
+                )
+            )
         )
-        val decoded = decode<TestData>(
-            TestData.serializer(),
-            encoded
+        val encoded = encode<TestSealedList>(
+            TestSealedList.serializer(),
+            toEncode,
+            shouldEncodeElementDefault = true
         )
-        assertEquals(target, decoded)
+        val expected = nativeMapOf(
+            "list" to nativeListOf(
+                nativeMapOf(
+                    "type" to "child",
+                    "map" to nativeMapOf(
+                        "key" to "value"
+                    ),
+                    "bool" to false
+                )
+            )
+        )
+        nativeAssertEquals(expected, encoded)
     }
 
     @Test
-    fun encodeDecodeSealedClassList() {
-        val target =
-            TestSealedList(list = listOf(TestSealed.ChildClass(map = emptyMap(), bool = false)))
-        val encoded = encode<TestSealedList>(
-            TestSealedList.serializer(),
-            target,
-            shouldEncodeElementDefault = true
+    fun decodeSealedClassList() {
+        val toDecode = nativeMapOf(
+            "list" to nativeListOf(
+                nativeMapOf(
+                    "type" to "child",
+                    "map" to nativeMapOf(
+                        "key" to "value"
+                    ),
+                    "bool" to false
+                )
+            )
         )
-        val decoded = decode<TestSealedList>(
+        val decoded = decode(
             TestSealedList.serializer(),
-            encoded
+            toDecode
         )
-        assertEquals(target, decoded)
+        val expected = TestSealedList(
+            list = listOf(
+                TestSealed.ChildClass(
+                    map = mapOf("key" to "value"),
+                    bool = false
+                )
+            )
+        )
+
+        assertEquals(expected, decoded)
     }
 }

--- a/firebase-common/src/commonTest/kotlin/dev/gitlive/firebase/EncodersTest.kt
+++ b/firebase-common/src/commonTest/kotlin/dev/gitlive/firebase/EncodersTest.kt
@@ -25,6 +25,9 @@ sealed class TestSealed {
     data class ChildClass(val map: Map<String, String>, val bool: Boolean = false): TestSealed()
 }
 
+@Serializable
+data class TestSealedList(val list: List<TestSealed>)
+
 class EncodersTest {
     @Test
     fun encodeMap() {
@@ -73,5 +76,36 @@ class EncodersTest {
     fun decodeSealedClass() {
         val decoded = decode(TestSealed.serializer(), nativeMapOf("type" to "child", "map" to nativeMapOf("key" to "value"), "bool" to true))
         assertEquals(TestSealed.ChildClass(mapOf("key" to "value"), true), decoded)
+    }
+
+    @Test
+    fun encodeDecodeSealedClass() {
+        val target = TestData(mapOf("key" to "value"), true)
+        val encoded = encode<TestData>(
+            TestData.serializer(),
+            target,
+            shouldEncodeElementDefault = false
+        )
+        val decoded = decode<TestData>(
+            TestData.serializer(),
+            encoded
+        )
+        nativeAssertEquals(target, decoded)
+    }
+
+    @Test
+    fun encodeDecodeSealedClassList() {
+        val target =
+            TestSealedList(list = listOf(TestSealed.ChildClass(map = emptyMap(), bool = false)))
+        val encoded = encode<TestSealedList>(
+            TestSealedList.serializer(),
+            target,
+            shouldEncodeElementDefault = true
+        )
+        val decoded = decode<TestSealedList>(
+            TestSealedList.serializer(),
+            encoded
+        )
+        nativeAssertEquals(target, decoded)
     }
 }

--- a/firebase-common/src/iosMain/kotlin/dev/gitlive/firebase/_decoders.kt
+++ b/firebase-common/src/iosMain/kotlin/dev/gitlive/firebase/_decoders.kt
@@ -11,7 +11,14 @@ import kotlinx.serialization.descriptors.StructureKind
 
 actual fun FirebaseDecoder.structureDecoder(descriptor: SerialDescriptor): CompositeDecoder = when(descriptor.kind) {
     StructureKind.CLASS, StructureKind.OBJECT, PolymorphicKind.SEALED -> (value as Map<*, *>).let { map ->
-        FirebaseClassDecoder(map.size, { map.containsKey(it) }) { desc, index -> map[desc.getElementName(index)] }
+        FirebaseClassDecoder(map.size, { map.containsKey(it) }) { desc, index ->
+            val elementName = desc.getElementName(index)
+            if (desc.kind is PolymorphicKind && elementName == "value") {
+                map
+            } else {
+                map[desc.getElementName(index)]
+            }
+        }
     }
     StructureKind.LIST -> (value as List<*>).let {
         FirebaseCompositeDecoder(it.size) { _, index -> it[index] }

--- a/firebase-common/src/jsMain/kotlin/dev/gitlive/firebase/_decoders.kt
+++ b/firebase-common/src/jsMain/kotlin/dev/gitlive/firebase/_decoders.kt
@@ -13,8 +13,13 @@ import kotlin.js.Json
 @Suppress("UNCHECKED_CAST_TO_EXTERNAL_INTERFACE")
 actual fun FirebaseDecoder.structureDecoder(descriptor: SerialDescriptor): CompositeDecoder = when(descriptor.kind) {
     StructureKind.CLASS, StructureKind.OBJECT, PolymorphicKind.SEALED -> (value as Json).let { json ->
-        FirebaseClassDecoder(js("Object").keys(value).length as Int, { json[it] != undefined }) {
-                desc, index -> json[desc.getElementName(index)]
+        FirebaseClassDecoder(js("Object").keys(value).length as Int, { json[it] != undefined }) { desc, index ->
+            val elementName = desc.getElementName(index)
+            if (desc.kind is PolymorphicKind && elementName == "value") {
+                json
+            } else {
+                json[desc.getElementName(index)]
+            }
         }
     }
     StructureKind.LIST -> (value as Array<*>).let {


### PR DESCRIPTION
Hi!,

Thanks a lot for the huge effort of making available this library. 

While using the SDK to store a list of sealed classes I ran into the following error on decoding.
`NullPointerException: null cannot be cast to non-null type kotlin.collections.Map<*, *>`

I managed to track it to `firebase-common/androidMain/_decoders.kt` `FirebaseDecoder.structureDecoder` function. (and also its iOS equivalent)

It happens because the descriptor is expecting a `value` property that was not encoded. I managed to fix it with the following
```kotlin
StructureKind.CLASS, StructureKind.OBJECT, PolymorphicKind.SEALED -> (value as Map<*, *>).let { map ->
        FirebaseClassDecoder(decodeDouble, map.size, { map.containsKey(it) }) { desc, index ->
            val elementName = desc.getElementName(index)
            if (desc.kind is PolymorphicKind && elementName == "value") {
                map
            } else {
                map[desc.getElementName(index)]
            }
        }
    }
```
And similar for the iOS but maybe there is a more elegant way?

I will open an issue with the same comment and link this PR