### PR TITLE
Task/103/android phone auth change

### DIFF
--- a/firebase-auth/src/androidMain/kotlin/dev/gitlive/firebase/auth/credentials.kt
+++ b/firebase-auth/src/androidMain/kotlin/dev/gitlive/firebase/auth/credentials.kt
@@ -90,7 +90,7 @@ actual class PhoneAuthProvider(val android: com.google.firebase.auth.PhoneAuthPr
             PhoneAuthProvider.OnVerificationStateChangedCallbacks() {
 
             override fun onCodeSent(verificationId: String, forceResending: PhoneAuthProvider.ForceResendingToken) {
-                onRecievedVerificationID(verificationId = verificationId)
+                verificationProvider.onRecievedVerificationID(verificationId = verificationId)
                 verificationProvider.codeSent { android.verifyPhoneNumber(phoneNumber, verificationProvider.timeout, verificationProvider.unit, verificationProvider.activity, this, forceResending) }
             }
 

--- a/firebase-auth/src/androidMain/kotlin/dev/gitlive/firebase/auth/credentials.kt
+++ b/firebase-auth/src/androidMain/kotlin/dev/gitlive/firebase/auth/credentials.kt
@@ -90,6 +90,7 @@ actual class PhoneAuthProvider(val android: com.google.firebase.auth.PhoneAuthPr
             PhoneAuthProvider.OnVerificationStateChangedCallbacks() {
 
             override fun onCodeSent(verificationId: String, forceResending: PhoneAuthProvider.ForceResendingToken) {
+                onCodeAutoRetrievalTimeOut(verificationId = verificationId)
                 verificationProvider.codeSent { android.verifyPhoneNumber(phoneNumber, verificationProvider.timeout, verificationProvider.unit, verificationProvider.activity, this, forceResending) }
             }
 
@@ -123,6 +124,7 @@ actual interface PhoneVerificationProvider {
     val activity: Activity
     val timeout: Long
     val unit: TimeUnit
+    fun onRecievedVerificationID(verificationID: String)
     fun codeSent(triggerResend: (Unit) -> Unit)
     suspend fun getVerificationCode(): String
 }

--- a/firebase-auth/src/androidMain/kotlin/dev/gitlive/firebase/auth/credentials.kt
+++ b/firebase-auth/src/androidMain/kotlin/dev/gitlive/firebase/auth/credentials.kt
@@ -90,7 +90,7 @@ actual class PhoneAuthProvider(val android: com.google.firebase.auth.PhoneAuthPr
             PhoneAuthProvider.OnVerificationStateChangedCallbacks() {
 
             override fun onCodeSent(verificationId: String, forceResending: PhoneAuthProvider.ForceResendingToken) {
-                onCodeAutoRetrievalTimeOut(verificationId = verificationId)
+                onRecievedVerificationID(verificationId = verificationId)
                 verificationProvider.codeSent { android.verifyPhoneNumber(phoneNumber, verificationProvider.timeout, verificationProvider.unit, verificationProvider.activity, this, forceResending) }
             }
 


### PR DESCRIPTION
This allows android to have the verificationID when auto verify fails.  This lets android have the verificationID to manually continue 