### PR TITLE
Re-enable ios constructors

### DIFF
--- a/firebase-auth/src/iosMain/kotlin/dev/gitlive/firebase/auth/auth.kt
+++ b/firebase-auth/src/iosMain/kotlin/dev/gitlive/firebase/auth/auth.kt
@@ -19,8 +19,7 @@ import platform.Foundation.*
 actual val Firebase.auth
     get() = FirebaseAuth(FIRAuth.auth())
 
-actual fun Firebase.auth(app: FirebaseApp): FirebaseAuth = TODO("Come back to issue")
-//    FirebaseAuth(FIRAuth.authWithApp(app.ios))
+actual fun Firebase.auth(app: FirebaseApp): FirebaseAuth = FirebaseAuth(FIRAuth.authWithApp(app.ios))
 
 actual class FirebaseAuth internal constructor(val ios: FIRAuth) {
 

--- a/firebase-auth/src/iosMain/kotlin/dev/gitlive/firebase/auth/auth.kt
+++ b/firebase-auth/src/iosMain/kotlin/dev/gitlive/firebase/auth/auth.kt
@@ -19,7 +19,9 @@ import platform.Foundation.*
 actual val Firebase.auth
     get() = FirebaseAuth(FIRAuth.auth())
 
-actual fun Firebase.auth(app: FirebaseApp): FirebaseAuth = FirebaseAuth(FIRAuth.authWithApp(app.ios))
+actual fun Firebase.auth(app: FirebaseApp): FirebaseAuth = FirebaseAuth(
+    FIRAuth.authWithApp(app.ios as objcnames.classes.FIRApp)
+)
 
 actual class FirebaseAuth internal constructor(val ios: FIRAuth) {
 

--- a/firebase-common/src/jsMain/kotlin/dev/gitlive/firebase/externals.kt
+++ b/firebase-common/src/jsMain/kotlin/dev/gitlive/firebase/externals.kt
@@ -276,7 +276,6 @@ external object firebase {
     object functions {
         class Functions {
             fun httpsCallable(name: String, options: Json?): HttpsCallable
-            fun useFunctionsEmulator(origin: String)
             fun useEmulator(host: String, port: Int)
         }
         interface HttpsCallableResult {

--- a/firebase-config/src/iosMain/kotlin/dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfig.kt
+++ b/firebase-config/src/iosMain/kotlin/dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfig.kt
@@ -19,8 +19,9 @@ import platform.Foundation.timeIntervalSince1970
 actual val Firebase.remoteConfig: FirebaseRemoteConfig
     get() = FirebaseRemoteConfig(FIRRemoteConfig.remoteConfig())
 
-actual fun Firebase.remoteConfig(app: FirebaseApp): FirebaseRemoteConfig =
-    FirebaseRemoteConfig(FIRRemoteConfig.remoteConfigWithApp(Firebase.app.ios))
+actual fun Firebase.remoteConfig(app: FirebaseApp): FirebaseRemoteConfig = FirebaseRemoteConfig(
+    FIRRemoteConfig.remoteConfigWithApp(Firebase.app.ios as objcnames.classes.FIRApp)
+)
 
 actual class FirebaseRemoteConfig internal constructor(val ios: FIRRemoteConfig) {
     actual val all: Map<String, FirebaseRemoteConfigValue>

--- a/firebase-config/src/iosMain/kotlin/dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfig.kt
+++ b/firebase-config/src/iosMain/kotlin/dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfig.kt
@@ -19,8 +19,8 @@ import platform.Foundation.timeIntervalSince1970
 actual val Firebase.remoteConfig: FirebaseRemoteConfig
     get() = FirebaseRemoteConfig(FIRRemoteConfig.remoteConfig())
 
-actual fun Firebase.remoteConfig(app: FirebaseApp): FirebaseRemoteConfig = TODO("Come back to issue")
-//    FirebaseRemoteConfig(FIRRemoteConfig.remoteConfigWithApp(Firebase.app.ios))
+actual fun Firebase.remoteConfig(app: FirebaseApp): FirebaseRemoteConfig =
+    FirebaseRemoteConfig(FIRRemoteConfig.remoteConfigWithApp(Firebase.app.ios))
 
 actual class FirebaseRemoteConfig internal constructor(val ios: FIRRemoteConfig) {
     actual val all: Map<String, FirebaseRemoteConfigValue>

--- a/firebase-database/src/iosMain/kotlin/dev/gitlive/firebase/database/database.kt
+++ b/firebase-database/src/iosMain/kotlin/dev/gitlive/firebase/database/database.kt
@@ -33,11 +33,11 @@ actual val Firebase.database
 actual fun Firebase.database(url: String) =
     FirebaseDatabase(FIRDatabase.databaseWithURL(url))
 
-actual fun Firebase.database(app: FirebaseApp): FirebaseDatabase = TODO("Come back to issue")
-//    FirebaseDatabase(FIRDatabase.databaseForApp(app.ios))
+actual fun Firebase.database(app: FirebaseApp): FirebaseDatabase =
+    FirebaseDatabase(FIRDatabase.databaseForApp(app.ios))
 
-actual fun Firebase.database(app: FirebaseApp, url: String): FirebaseDatabase = TODO("Come back to issue")
-//    FirebaseDatabase(FIRDatabase.databaseForApp(app.ios, url))
+actual fun Firebase.database(app: FirebaseApp, url: String): FirebaseDatabase =
+    FirebaseDatabase(FIRDatabase.databaseForApp(app.ios, url))
 
 actual class FirebaseDatabase internal constructor(val ios: FIRDatabase) {
 

--- a/firebase-database/src/iosMain/kotlin/dev/gitlive/firebase/database/database.kt
+++ b/firebase-database/src/iosMain/kotlin/dev/gitlive/firebase/database/database.kt
@@ -33,11 +33,13 @@ actual val Firebase.database
 actual fun Firebase.database(url: String) =
     FirebaseDatabase(FIRDatabase.databaseWithURL(url))
 
-actual fun Firebase.database(app: FirebaseApp): FirebaseDatabase =
-    FirebaseDatabase(FIRDatabase.databaseForApp(app.ios))
+actual fun Firebase.database(app: FirebaseApp): FirebaseDatabase = FirebaseDatabase(
+    FIRDatabase.databaseForApp(app.ios as objcnames.classes.FIRApp)
+)
 
-actual fun Firebase.database(app: FirebaseApp, url: String): FirebaseDatabase =
-    FirebaseDatabase(FIRDatabase.databaseForApp(app.ios, url))
+actual fun Firebase.database(app: FirebaseApp, url: String): FirebaseDatabase = FirebaseDatabase(
+    FIRDatabase.databaseForApp(app.ios as objcnames.classes.FIRApp, url)
+)
 
 actual class FirebaseDatabase internal constructor(val ios: FIRDatabase) {
 

--- a/firebase-firestore/src/iosMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
+++ b/firebase-firestore/src/iosMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
@@ -21,8 +21,9 @@ import platform.Foundation.NSNull
 actual val Firebase.firestore get() =
     FirebaseFirestore(FIRFirestore.firestore())
 
-actual fun Firebase.firestore(app: FirebaseApp): FirebaseFirestore =
-    FirebaseFirestore(FIRFirestore.firestoreForApp(app.ios))
+actual fun Firebase.firestore(app: FirebaseApp): FirebaseFirestore = FirebaseFirestore(
+    FIRFirestore.firestoreForApp(app.ios as objcnames.classes.FIRApp)
+)
 
 @Suppress("UNCHECKED_CAST")
 actual class FirebaseFirestore(val ios: FIRFirestore) {

--- a/firebase-firestore/src/iosMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
+++ b/firebase-firestore/src/iosMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
@@ -21,10 +21,8 @@ import platform.Foundation.NSNull
 actual val Firebase.firestore get() =
     FirebaseFirestore(FIRFirestore.firestore())
 
-actual fun Firebase.firestore(app: FirebaseApp): FirebaseFirestore = TODO("Come back to issue")
-//actual fun Firebase.firestore(app: FirebaseApp): FirebaseFirestore {
-//    return FirebaseFirestore(FIRFirestore.firestoreForApp(app.ios))
-//}
+actual fun Firebase.firestore(app: FirebaseApp): FirebaseFirestore =
+    FirebaseFirestore(FIRFirestore.firestoreForApp(app.ios))
 
 @Suppress("UNCHECKED_CAST")
 actual class FirebaseFirestore(val ios: FIRFirestore) {

--- a/firebase-functions/src/androidMain/kotlin/dev/gitlive/firebase/functions/functions.kt
+++ b/firebase-functions/src/androidMain/kotlin/dev/gitlive/firebase/functions/functions.kt
@@ -29,8 +29,6 @@ actual class FirebaseFunctions internal constructor(val android: com.google.fire
     actual fun httpsCallable(name: String, timeout: Long?) =
         HttpsCallableReference(android.getHttpsCallable(name).apply { timeout?.let { setTimeout(it, TimeUnit.MILLISECONDS) } })
 
-    actual fun useFunctionsEmulator(origin: String) = android.useFunctionsEmulator(origin)
-
     actual fun useEmulator(host: String, port: Int) = android.useEmulator(host, port)
 }
 

--- a/firebase-functions/src/commonMain/kotlin/dev/gitlive/firebase/functions/functions.kt
+++ b/firebase-functions/src/commonMain/kotlin/dev/gitlive/firebase/functions/functions.kt
@@ -13,9 +13,6 @@ import kotlinx.serialization.SerializationStrategy
 expect class FirebaseFunctions {
     fun httpsCallable(name: String, timeout: Long? = null): HttpsCallableReference
     fun useEmulator(host: String, port: Int)
-
-    @Deprecated("Use useEmulator(java.lang.String,int) to connect to the emulator.")
-    fun useFunctionsEmulator(origin: String)
 }
 
 expect class HttpsCallableReference {

--- a/firebase-functions/src/iosMain/kotlin/dev/gitlive/firebase/functions/functions.kt
+++ b/firebase-functions/src/iosMain/kotlin/dev/gitlive/firebase/functions/functions.kt
@@ -21,11 +21,16 @@ actual val Firebase.functions
 actual fun Firebase.functions(region: String) =
     FirebaseFunctions(FIRFunctions.functionsForRegion(region))
 
-actual fun Firebase.functions(app: FirebaseApp): FirebaseFunctions =
-    FirebaseFunctions(FIRFunctions.functionsForApp(app.ios))
+actual fun Firebase.functions(app: FirebaseApp): FirebaseFunctions = FirebaseFunctions(
+    FIRFunctions.functionsForApp(app.ios as objcnames.classes.FIRApp)
+)
 
-actual fun Firebase.functions(app: FirebaseApp, region: String): FirebaseFunctions =
-    FirebaseFunctions(FIRFunctions.functionsForApp(app.ios, region = region))
+actual fun Firebase.functions(
+    app: FirebaseApp,
+    region: String,
+): FirebaseFunctions = FirebaseFunctions(
+    FIRFunctions.functionsForApp(app.ios as objcnames.classes.FIRApp, region = region)
+)
 
 actual class FirebaseFunctions internal constructor(val ios: FIRFunctions) {
     actual fun httpsCallable(name: String, timeout: Long?) =

--- a/firebase-functions/src/iosMain/kotlin/dev/gitlive/firebase/functions/functions.kt
+++ b/firebase-functions/src/iosMain/kotlin/dev/gitlive/firebase/functions/functions.kt
@@ -21,18 +21,15 @@ actual val Firebase.functions
 actual fun Firebase.functions(region: String) =
     FirebaseFunctions(FIRFunctions.functionsForRegion(region))
 
-actual fun Firebase.functions(app: FirebaseApp): FirebaseFunctions = TODO("Come back to issue")
-//    FirebaseFunctions(FIRFunctions.functionsForApp(app.ios))
+actual fun Firebase.functions(app: FirebaseApp): FirebaseFunctions =
+    FirebaseFunctions(FIRFunctions.functionsForApp(app.ios))
 
-actual fun Firebase.functions(app: FirebaseApp, region: String): FirebaseFunctions = TODO("Come back to issue")
-//    FirebaseFunctions(FIRFunctions.functionsForApp(app.ios, region = region))
+actual fun Firebase.functions(app: FirebaseApp, region: String): FirebaseFunctions =
+    FirebaseFunctions(FIRFunctions.functionsForApp(app.ios, region = region))
 
 actual class FirebaseFunctions internal constructor(val ios: FIRFunctions) {
     actual fun httpsCallable(name: String, timeout: Long?) =
         HttpsCallableReference(ios.HTTPSCallableWithName(name).apply { timeout?.let { setTimeoutInterval(it/1000.0) } })
-
-    actual fun useFunctionsEmulator(origin: String): Unit = TODO("Come back to issue")
-        //ios.useFunctionsEmulatorOrigin(origin)
 
     actual fun useEmulator(host: String, port: Int) = ios.useEmulatorWithHost(host, port.toLong())
 }

--- a/firebase-functions/src/jsMain/kotlin/dev/gitlive/firebase/functions/functions.kt
+++ b/firebase-functions/src/jsMain/kotlin/dev/gitlive/firebase/functions/functions.kt
@@ -26,8 +26,6 @@ actual class FirebaseFunctions internal constructor(val js: firebase.functions.F
     actual fun httpsCallable(name: String, timeout: Long?) =
         rethrow { HttpsCallableReference(js.httpsCallable(name, timeout?.let { json("timeout" to timeout.toDouble()) })) }
 
-    actual fun useFunctionsEmulator(origin: String) = js.useFunctionsEmulator(origin)
-
     actual fun useEmulator(host: String, port: Int) = js.useEmulator(host, port)
 }
 

--- a/firebase-installations/src/iosMain/kotlin/dev/gitlive/firebase/installations/installations.kt
+++ b/firebase-installations/src/iosMain/kotlin/dev/gitlive/firebase/installations/installations.kt
@@ -10,8 +10,8 @@ import platform.Foundation.*
 actual val Firebase.installations
     get() = FirebaseInstallations(FIRInstallations.installations())
 
-actual fun Firebase.installations(app: FirebaseApp) : FirebaseInstallations = TODO("Come back to issue")
-//        = FirebaseInstallations(FIRInstallations.installationsWithApp(app.ios))
+actual fun Firebase.installations(app: FirebaseApp): FirebaseInstallations =
+    FirebaseInstallations(FIRInstallations.installationsWithApp(app.ios))
 
 actual class FirebaseInstallations internal constructor(val ios: FIRInstallations) {
 

--- a/firebase-installations/src/iosMain/kotlin/dev/gitlive/firebase/installations/installations.kt
+++ b/firebase-installations/src/iosMain/kotlin/dev/gitlive/firebase/installations/installations.kt
@@ -10,8 +10,9 @@ import platform.Foundation.*
 actual val Firebase.installations
     get() = FirebaseInstallations(FIRInstallations.installations())
 
-actual fun Firebase.installations(app: FirebaseApp): FirebaseInstallations =
-    FirebaseInstallations(FIRInstallations.installationsWithApp(app.ios))
+actual fun Firebase.installations(app: FirebaseApp): FirebaseInstallations = FirebaseInstallations(
+    FIRInstallations.installationsWithApp(app.ios as objcnames.classes.FIRApp)
+)
 
 actual class FirebaseInstallations internal constructor(val ios: FIRInstallations) {
 


### PR DESCRIPTION
#349 commented out these constructors due to compilation issues. ~~I think things are compiling fine now, for whatever reason, so I'm just uncommenting them back.~~ Looks like there's just some build-time confusion about `FirebaseApp` types that a force-cast alleviates. Thanks @Daeda88! 

Note: `fun useFunctionsEmulator(origin: String)` has been removed as it is no longer present in the latest Firebase version that this repo is now pointing to (it used to be deprecated).