### PR TITLE
Add support/handling for FirebaseAuthWeakPasswordException

### DIFF
--- a/firebase-auth/src/androidMain/kotlin/dev/gitlive/firebase/auth/auth.kt
+++ b/firebase-auth/src/androidMain/kotlin/dev/gitlive/firebase/auth/auth.kt
@@ -142,6 +142,7 @@ actual typealias FirebaseAuthException = com.google.firebase.auth.FirebaseAuthEx
 actual typealias FirebaseAuthActionCodeException = com.google.firebase.auth.FirebaseAuthActionCodeException
 actual typealias FirebaseAuthEmailException = com.google.firebase.auth.FirebaseAuthEmailException
 actual typealias FirebaseAuthInvalidCredentialsException = com.google.firebase.auth.FirebaseAuthInvalidCredentialsException
+actual typealias FirebaseAuthWeakPasswordException = com.google.firebase.auth.FirebaseAuthWeakPasswordException
 actual typealias FirebaseAuthInvalidUserException = com.google.firebase.auth.FirebaseAuthInvalidUserException
 actual typealias FirebaseAuthMultiFactorException = com.google.firebase.auth.FirebaseAuthMultiFactorException
 actual typealias FirebaseAuthRecentLoginRequiredException = com.google.firebase.auth.FirebaseAuthRecentLoginRequiredException

--- a/firebase-auth/src/commonMain/kotlin/dev/gitlive/firebase/auth/auth.kt
+++ b/firebase-auth/src/commonMain/kotlin/dev/gitlive/firebase/auth/auth.kt
@@ -78,7 +78,8 @@ data class AndroidPackageName(
 expect open class FirebaseAuthException : FirebaseException
 expect class FirebaseAuthActionCodeException : FirebaseAuthException
 expect class FirebaseAuthEmailException : FirebaseAuthException
-expect class FirebaseAuthInvalidCredentialsException : FirebaseAuthException
+expect open class FirebaseAuthInvalidCredentialsException : FirebaseAuthException
+expect class FirebaseAuthWeakPasswordException: FirebaseAuthInvalidCredentialsException
 expect class FirebaseAuthInvalidUserException : FirebaseAuthException
 expect class FirebaseAuthMultiFactorException: FirebaseAuthException
 expect class FirebaseAuthRecentLoginRequiredException : FirebaseAuthException

--- a/firebase-auth/src/iosMain/kotlin/dev/gitlive/firebase/auth/auth.kt
+++ b/firebase-auth/src/iosMain/kotlin/dev/gitlive/firebase/auth/auth.kt
@@ -130,6 +130,7 @@ actual open class FirebaseAuthException(message: String): FirebaseException(mess
 actual open class FirebaseAuthActionCodeException(message: String): FirebaseAuthException(message)
 actual open class FirebaseAuthEmailException(message: String): FirebaseAuthException(message)
 actual open class FirebaseAuthInvalidCredentialsException(message: String): FirebaseAuthException(message)
+actual open class FirebaseAuthWeakPasswordException(message: String): FirebaseAuthInvalidCredentialsException(message)
 actual open class FirebaseAuthInvalidUserException(message: String): FirebaseAuthException(message)
 actual open class FirebaseAuthMultiFactorException(message: String): FirebaseAuthException(message)
 actual open class FirebaseAuthRecentLoginRequiredException(message: String): FirebaseAuthException(message)
@@ -186,8 +187,9 @@ private fun NSError.toException() = when(domain) {
         FIRAuthErrorCodeInvalidVerificationCode,
         FIRAuthErrorCodeMissingVerificationID,
         FIRAuthErrorCodeMissingVerificationCode,
-        FIRAuthErrorCodeWeakPassword,
         FIRAuthErrorCodeInvalidCredential -> FirebaseAuthInvalidCredentialsException(toString())
+
+        FIRAuthErrorCodeWeakPassword -> FirebaseAuthWeakPasswordException(toString())
 
         FIRAuthErrorCodeInvalidUserToken -> FirebaseAuthInvalidUserException(toString())
 

--- a/firebase-auth/src/jsMain/kotlin/dev/gitlive/firebase/auth/auth.kt
+++ b/firebase-auth/src/jsMain/kotlin/dev/gitlive/firebase/auth/auth.kt
@@ -135,6 +135,7 @@ actual open class FirebaseAuthException(code: String?, cause: Throwable): Fireba
 actual open class FirebaseAuthActionCodeException(code: String?, cause: Throwable): FirebaseAuthException(code, cause)
 actual open class FirebaseAuthEmailException(code: String?, cause: Throwable): FirebaseAuthException(code, cause)
 actual open class FirebaseAuthInvalidCredentialsException(code: String?, cause: Throwable): FirebaseAuthException(code, cause)
+actual open class FirebaseAuthWeakPasswordException(code: String?, cause: Throwable): FirebaseAuthInvalidCredentialsException(code, cause)
 actual open class FirebaseAuthInvalidUserException(code: String?, cause: Throwable): FirebaseAuthException(code, cause)
 actual open class FirebaseAuthMultiFactorException(code: String?, cause: Throwable): FirebaseAuthException(code, cause)
 actual open class FirebaseAuthRecentLoginRequiredException(code: String?, cause: Throwable): FirebaseAuthException(code, cause)
@@ -161,6 +162,7 @@ private fun errorToException(cause: dynamic) = when(val code = cause.code?.toStr
     "auth/user-token-expired" -> FirebaseAuthInvalidUserException(code, cause)
     "auth/web-storage-unsupported" -> FirebaseAuthWebException(code, cause)
     "auth/network-request-failed" -> FirebaseNetworkException(code, cause)
+    "auth/weak-password" -> FirebaseAuthWeakPasswordException(code, cause)
     "auth/invalid-credential",
     "auth/invalid-verification-code",
     "auth/missing-verification-code",


### PR DESCRIPTION
Addresses #289 by adding support for the `FirebaseAuthWeakPasswordException` (https://firebase.google.com/docs/reference/kotlin/com/google/firebase/auth/FirebaseAuthWeakPasswordException) in the **firebase-auth** module.

- Marks `FirebaseAuthInvalidCredentialsException` as `open` so that it can be inherited from (more info below).
- Adds a new class `FirebaseAuthWeakPasswordException` that inherits from `FirebaseAuthInvalidCredentialsException`. This is done for two reasons:
   1.  In Firebase itself, the weak password exception inherits from the invalid credentials exception. This keeps that same structure in this library.
   2. It prevents breaking changes. Existing code in consumer applications that is expecting `FirebaseAuthInvalidCredentialsException` will continue to function normally, since the new `FirebaseAuthWeakPasswordException` IS a `FirebaseAuthInvalidCredentialsException`.
- Implements the `FirebaseAuthWeakPasswordException` for all platforms (android, iOS, js).   