### PR TITLE
Add listAll to StorageReference and reference to FirebaseStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,4 +236,10 @@ If you are building a Kotlin multiplatform library which will be consumed from J
 }
 ```
 
-
+## Contributing
+If you'd like to contribute to this project then you can fork this repository. 
+You can build and test the project locally.
+1. Open the project in IntelliJ IDEA.
+2. Install cocoapods via `sudo gem install -n /usr/local/bin cocoapods`
+3. Install the GitLive plugin into IntelliJ
+4. After a gradle sync then run `firebase-storage:publishToMavenLocal`

--- a/README.md
+++ b/README.md
@@ -242,4 +242,4 @@ You can build and test the project locally.
 1. Open the project in IntelliJ IDEA.
 2. Install cocoapods via `sudo gem install -n /usr/local/bin cocoapods`
 3. Install the GitLive plugin into IntelliJ
-4. After a gradle sync then run `firebase-storage:publishToMavenLocal`
+4. After a gradle sync then run `publishToMavenLocal`

--- a/firebase-common/src/jsMain/kotlin/dev/gitlive/firebase/externals.kt
+++ b/firebase-common/src/jsMain/kotlin/dev/gitlive/firebase/externals.kt
@@ -518,6 +518,7 @@ external object firebase {
             fun setMaxOperationRetryTime(time: Double): Unit
             fun setMaxUploadRetryTime(time: Double): Unit
             fun useEmulator(host: String, port: Int)
+            fun ref(): Reference
         }
 
         open class Reference {

--- a/firebase-storage/src/androidMain/kotlin/dev/gitlive/firebase/storage/storage.kt
+++ b/firebase-storage/src/androidMain/kotlin/dev/gitlive/firebase/storage/storage.kt
@@ -43,6 +43,7 @@ actual class FirebaseStorage(val android: com.google.firebase.storage.FirebaseSt
         android.useEmulator(host, port)
     }
 
+    actual val reference = StorageReference(android.reference)
 }
 
 actual class StorageReference(val android: com.google.firebase.storage.StorageReference) {
@@ -58,6 +59,8 @@ actual class StorageReference(val android: com.google.firebase.storage.StorageRe
     actual suspend fun delete() = android.delete().await().run { Unit }
 
     actual suspend fun getDownloadUrl(): String = android.downloadUrl.await().toString()
+
+    actual suspend fun listAll(): ListResult = ListResult(android.listAll().await())
 
     actual fun putFileResumable(file: File): ProgressFlow {
         val android = android.putFile(file.uri)
@@ -86,6 +89,12 @@ actual class StorageReference(val android: com.google.firebase.storage.StorageRe
             override fun cancel() = android.cancel().run {}
         }
     }
+}
+
+actual class ListResult(val android: com.google.firebase.storage.ListResult) {
+    actual val prefixes: List<StorageReference> get() = android.prefixes.map { StorageReference(it) }
+    actual val items: List<StorageReference> get() = android.items.map { StorageReference(it) }
+    actual val pageToken: String? get() = android.pageToken
 }
 
 actual class File(val uri: Uri)

--- a/firebase-storage/src/androidMain/kotlin/dev/gitlive/firebase/storage/storage.kt
+++ b/firebase-storage/src/androidMain/kotlin/dev/gitlive/firebase/storage/storage.kt
@@ -91,10 +91,10 @@ actual class StorageReference(val android: com.google.firebase.storage.StorageRe
     }
 }
 
-actual class ListResult(val android: com.google.firebase.storage.ListResult) {
-    actual val prefixes: List<StorageReference> get() = android.prefixes.map { StorageReference(it) }
-    actual val items: List<StorageReference> get() = android.items.map { StorageReference(it) }
-    actual val pageToken: String? get() = android.pageToken
+actual class ListResult(android: com.google.firebase.storage.ListResult) {
+    actual val prefixes: List<StorageReference> = android.prefixes.map { StorageReference(it) }
+    actual val items: List<StorageReference> = android.items.map { StorageReference(it) }
+    actual val pageToken: String? = android.pageToken
 }
 
 actual class File(val uri: Uri)

--- a/firebase-storage/src/commonMain/kotlin/dev/gitlive/firebase/storage/storage.kt
+++ b/firebase-storage/src/commonMain/kotlin/dev/gitlive/firebase/storage/storage.kt
@@ -18,6 +18,8 @@ expect class FirebaseStorage {
     fun setMaxOperationRetryTimeMillis(maxOperationRetryTimeMillis: Long)
     fun setMaxUploadRetryTimeMillis(maxUploadRetryTimeMillis: Long)
     fun useEmulator(host: String, port: Int)
+
+    val reference: StorageReference
 }
 
 expect class StorageReference {
@@ -34,8 +36,15 @@ expect class StorageReference {
 
     suspend fun getDownloadUrl(): String
 
-    fun putFileResumable(file: File): ProgressFlow
+    suspend fun listAll(): ListResult
 
+    fun putFileResumable(file: File): ProgressFlow
+}
+
+expect class ListResult {
+    val prefixes: List<StorageReference>
+    val items: List<StorageReference>
+    val pageToken: String?
 }
 
 expect class File

--- a/firebase-storage/src/jsMain/kotlin/dev/gitlive/firebase/storage/storage.kt
+++ b/firebase-storage/src/jsMain/kotlin/dev/gitlive/firebase/storage/storage.kt
@@ -38,6 +38,7 @@ actual class FirebaseStorage(val js: firebase.storage.Storage) {
         js.useEmulator(host, port)
     }
 
+    actual val reference: StorageReference get() = TODO()
 }
 
 actual class StorageReference(val js: firebase.storage.Reference) {
@@ -53,6 +54,8 @@ actual class StorageReference(val js: firebase.storage.Reference) {
     actual suspend fun delete() = rethrow { js.delete().await() }
 
     actual suspend fun getDownloadUrl(): String = rethrow { js.getDownloadURL().await().toString() }
+
+    actual suspend fun listAll(): ListResult = rethrow { ListResult(js.listAll().await()) }
 
     actual fun putFileResumable(file: File): ProgressFlow = rethrow {
         val uploadTask = js.put(file)
@@ -83,6 +86,12 @@ actual class StorageReference(val js: firebase.storage.Reference) {
         }
     }
 
+}
+
+actual class ListResult(js: firebase.storage.ListResult) {
+    actual val prefixes: List<StorageReference> = js.prefixes.map { StorageReference(it) }
+    actual val items: List<StorageReference> = js.items.map { StorageReference(it) }
+    actual val pageToken: String? = js.nextPageToken
 }
 
 actual typealias File = org.w3c.files.File

--- a/firebase-storage/src/jsMain/kotlin/dev/gitlive/firebase/storage/storage.kt
+++ b/firebase-storage/src/jsMain/kotlin/dev/gitlive/firebase/storage/storage.kt
@@ -38,7 +38,7 @@ actual class FirebaseStorage(val js: firebase.storage.Storage) {
         js.useEmulator(host, port)
     }
 
-    actual val reference: StorageReference get() = TODO()
+    actual val reference: StorageReference get() = StorageReference(js.ref())
 }
 
 actual class StorageReference(val js: firebase.storage.Reference) {


### PR DESCRIPTION
This is adding some api surface to firebase storage. Also a little change to the readme to give some clarity of how to work on this project.

I was able to build this locally and consume it in a separate KMM project to access firebase storage. So that's fantastic.