### PR TITLE
Fixed issue where crashlytics would put different crashes under the s…

### DIFF
--- a/firebase-crashlytics/src/iosMain/kotlin/dev/gitlive/firebase/crashlytics/crashlytics.kt
+++ b/firebase-crashlytics/src/iosMain/kotlin/dev/gitlive/firebase/crashlytics/crashlytics.kt
@@ -43,5 +43,5 @@ private fun Throwable.asNSError(): NSError {
     if (message != null) {
         userInfo[NSLocalizedDescriptionKey] = message
     }
-    return NSError.errorWithDomain("KotlinException", 0, userInfo)
+    return NSError.errorWithDomain(this::class.qualifiedName, 0, userInfo)
 }


### PR DESCRIPTION
…ame crash

I noticed that when using this method on ios to report a crash, it was bundling all the crashes under as one crash. At first i thought it was client code but then i dug a little deeper and realised it was because of this sdk.
This fix should group the same exceptions together which is alot more granular than just one exception