### PR TITLE
Move FieldPath.documentId to companion object

### DIFF
--- a/firebase-firestore/src/androidMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
+++ b/firebase-firestore/src/androidMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
@@ -409,13 +409,18 @@ actual class SnapshotMetadata(val android: com.google.firebase.firestore.Snapsho
 }
 
 actual class FieldPath private constructor(val android: com.google.firebase.firestore.FieldPath) {
+
+    actual companion object {
+        actual val documentId = FieldPath(com.google.firebase.firestore.FieldPath.documentId())
+    }
+
     actual constructor(vararg fieldNames: String) : this(
         com.google.firebase.firestore.FieldPath.of(
             *fieldNames
         )
     )
 
-    actual val documentId: FieldPath get() = FieldPath(com.google.firebase.firestore.FieldPath.documentId())
+    actual val documentId: FieldPath get() = FieldPath.documentId
     actual val encoded: EncodedFieldPath = android
     override fun equals(other: Any?): Boolean = other is FieldPath && android == other.android
     override fun hashCode(): Int = android.hashCode()

--- a/firebase-firestore/src/commonMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
+++ b/firebase-firestore/src/commonMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
@@ -544,6 +544,10 @@ expect class SnapshotMetadata {
 }
 
 expect class FieldPath(vararg fieldNames: String) {
+    companion object {
+        val documentId: FieldPath
+    }
+    @Deprecated("Use companion object instead", replaceWith = ReplaceWith("FieldPath.documentId"))
     val documentId: FieldPath
     val encoded: EncodedFieldPath
 }

--- a/firebase-firestore/src/commonTest/kotlin/dev/gitlive/firebase/firestore/firestore.kt
+++ b/firebase-firestore/src/commonTest/kotlin/dev/gitlive/firebase/firestore/firestore.kt
@@ -658,7 +658,6 @@ class FirebaseFirestoreTest {
         assertEquals(setOf(DocumentWithTimestamp(futureTimestamp)), gtQueryResult)
     }
 
-
     @Test
     fun testGeoPointSerialization() = runTest {
         @Serializable
@@ -1015,6 +1014,16 @@ class FirebaseFirestoreTest {
                 )
             }
         andOrQuery.assertDocuments(FirestoreTest.serializer(), testOne)
+    }
+
+    @Test
+    fun testQueryByDocumentId() = runTest {
+        setupFirestoreData()
+
+        val fieldQuery = firestore
+            .collection("testFirestoreQuerying")
+            .where { FieldPath.documentId equalTo "one" }
+        fieldQuery.assertDocuments(FirestoreTest.serializer(), testOne)
     }
 
     private suspend fun setupFirestoreData(

--- a/firebase-firestore/src/iosMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
+++ b/firebase-firestore/src/iosMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
@@ -436,8 +436,11 @@ actual class SnapshotMetadata(val ios: FIRSnapshotMetadata) {
 }
 
 actual class FieldPath private constructor(val ios: FIRFieldPath) {
+    actual companion object {
+        actual val documentId = FieldPath(FIRFieldPath.documentID())
+    }
     actual constructor(vararg fieldNames: String) : this(FIRFieldPath(fieldNames.asList()))
-    actual val documentId: FieldPath get() = FieldPath(FIRFieldPath.documentID())
+    actual val documentId: FieldPath get() = FieldPath.documentId
     actual val encoded: EncodedFieldPath = ios
     override fun equals(other: Any?): Boolean = other is FieldPath && ios == other.ios
     override fun hashCode(): Int = ios.hashCode()

--- a/firebase-firestore/src/jsMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
+++ b/firebase-firestore/src/jsMain/kotlin/dev/gitlive/firebase/firestore/firestore.kt
@@ -438,10 +438,14 @@ actual class SnapshotMetadata(val js: JsSnapshotMetadata) {
 }
 
 actual class FieldPath private constructor(val js: JsFieldPath) {
+
+    actual companion object {
+        actual val documentId = FieldPath(JsFieldPath.documentId)
+    }
     actual constructor(vararg fieldNames: String) : this(dev.gitlive.firebase.firestore.rethrow {
         js("Reflect").construct(JsFieldPath, fieldNames).unsafeCast<JsFieldPath>()
     })
-    actual val documentId: FieldPath get() = FieldPath(JsFieldPath.documentId)
+    actual val documentId: FieldPath get() = FieldPath.documentId
     actual val encoded: EncodedFieldPath = js
     override fun equals(other: Any?): Boolean = other is FieldPath && js.isEqual(other.js)
     override fun hashCode(): Int = js.hashCode()


### PR DESCRIPTION
Reason for this move is that:
1) It is a static property so it should be in a companion object
2) At least on iOS, doing `FieldPath().documentId` would crash since fieldPath needs at least one fieldName. So you'd have to call `FieldPath("fakePath").documentId` which is obviously not good