### PR TITLE
Added missing event params

### DIFF
--- a/firebase-analytics/src/commonMain/kotlin/dev/gitlive/firebase/analytics/AnalyticEventConstants.kt
+++ b/firebase-analytics/src/commonMain/kotlin/dev/gitlive/firebase/analytics/AnalyticEventConstants.kt
@@ -99,6 +99,8 @@ object FirebaseAnalyticsParam {
     const val PROMOTION_NAME: String = "promotion_name"
     const val QUANTITY: String = "quantity"
     const val SCORE: String = "score"
+    const val SCREEN_CLASS: String = "screen_class"
+    const val SCREEN_NAME: String = "screen_name"
     const val SEARCH_TERM: String = "search_term"
     const val SHIPPING: String = "shipping"
     const val SHIPPING_TIER: String = "shipping_tier"


### PR DESCRIPTION
Added missing parameter definitions for `SCREEN_NAME` and `SCREEN_CLASS` when logging the `SCREEN_VIEW` event