### PR TITLE
Add decoding Boolean from Number and String

### DIFF
--- a/firebase-common-internal/src/commonMain/kotlin/dev/gitlive/firebase/internal/decoders.kt
+++ b/firebase-common-internal/src/commonMain/kotlin/dev/gitlive/firebase/internal/decoders.kt
@@ -219,7 +219,7 @@ private fun decodeShort(value: Any?) = when(value) {
 
 private fun decodeBoolean(value: Any?) = when (value) {
     is Boolean -> value
-    is Number -> value.toInt() != 0
+    is Number -> value != 0
     is String -> value.toBoolean()
     else -> throw SerializationException("Expected $value to be boolean")
 }

--- a/firebase-common-internal/src/commonMain/kotlin/dev/gitlive/firebase/internal/decoders.kt
+++ b/firebase-common-internal/src/commonMain/kotlin/dev/gitlive/firebase/internal/decoders.kt
@@ -217,7 +217,12 @@ private fun decodeShort(value: Any?) = when(value) {
     else -> throw SerializationException("Expected $value to be short")
 }
 
-private fun decodeBoolean(value: Any?) = value as Boolean
+private fun decodeBoolean(value: Any?) = when (value) {
+    is Boolean -> value
+    is Number -> value.toInt() != 0
+    is String -> value.toBoolean()
+    else -> throw SerializationException("Expected $value to be boolean")
+}
 
 private fun decodeChar(value: Any?) = when(value) {
     is Number -> value.toChar()

--- a/firebase-database/src/commonTest/kotlin/dev/gitlive/firebase/database/database.kt
+++ b/firebase-database/src/commonTest/kotlin/dev/gitlive/firebase/database/database.kt
@@ -8,7 +8,6 @@ import dev.gitlive.firebase.runBlockingTest
 import dev.gitlive.firebase.runTest
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.Serializable
@@ -196,6 +195,20 @@ class FirebaseDatabaseTest {
         assertTrue(valueEvents.first().exists)
         reference.updateChildren(mapOf("test" to false, "nested" to mapOf("lastActivity" to null), "lastActivity" to null))
         assertFalse(valueEvents.first().exists)
+    }
+
+    @Test
+    fun testBooleanValue() = runTest {
+        ensureDatabaseConnected()
+        val reference = database.reference("FirebaseRealtimeDatabaseBooleanTest")
+        val falseRef = reference.child("false")
+        val trueRef = reference.child("true")
+        falseRef.setValue(false)
+        trueRef.setValue(true)
+        val falseValue = falseRef.valueEvents.first().value<Boolean>()
+        val trueValue = trueRef.valueEvents.first().value<Boolean>()
+        assertFalse(falseValue)
+        assertTrue(trueValue)
     }
 
     // Ignoring on Android Instrumented Tests due to bug in Firebase: https://github.com/firebase/firebase-android-sdk/issues/5870

--- a/firebase-database/src/commonTest/kotlin/dev/gitlive/firebase/database/database.kt
+++ b/firebase-database/src/commonTest/kotlin/dev/gitlive/firebase/database/database.kt
@@ -32,7 +32,7 @@ class FirebaseDatabaseTest {
     lateinit var database: FirebaseDatabase
 
     @Serializable
-    data class FirebaseDatabaseChildTest(val prop1: String? = null, val time: Double = 0.0)
+    data class FirebaseDatabaseChildTest(val prop1: String? = null, val time: Double = 0.0, val boolean: Boolean = true)
 
     @Serializable
     data class DatabaseTest(val title: String, val likes: Int = 0)
@@ -209,6 +209,15 @@ class FirebaseDatabaseTest {
         val trueValue = trueRef.valueEvents.first().value<Boolean>()
         assertFalse(falseValue)
         assertTrue(trueValue)
+    }
+
+    @Test
+    fun testBooleanValueInChild() = runTest {
+        ensureDatabaseConnected()
+        val reference = database.reference("FirebaseRealtimeDatabaseBooleanInChildTest")
+        reference.setValue(FirebaseDatabaseChildTest())
+        val value = reference.valueEvents.first().value<FirebaseDatabaseChildTest>()
+        assertEquals(FirebaseDatabaseChildTest(), value)
     }
 
     // Ignoring on Android Instrumented Tests due to bug in Firebase: https://github.com/firebase/firebase-android-sdk/issues/5870


### PR DESCRIPTION
This PR fixes crash when Number or String value is de-serialized into Boolean.
Also it may be as a workaround for #275.