### PR TITLE
Changes the use of Intervals/Timestamps as long into Kotlin Duration/Instant

### DIFF
--- a/firebase-analytics/api/android/firebase-analytics.api
+++ b/firebase-analytics/api/android/firebase-analytics.api
@@ -7,6 +7,7 @@ public final class dev/gitlive/firebase/analytics/AnalyticEventConstantsKt {
 public final class dev/gitlive/firebase/analytics/AnalyticsKt {
 	public static final fun logEvent (Ldev/gitlive/firebase/analytics/FirebaseAnalytics;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public static final fun setConsent (Ldev/gitlive/firebase/analytics/FirebaseAnalytics;Lkotlin/jvm/functions/Function1;)V
+	public static final fun setSessionTimeoutInterval (Ldev/gitlive/firebase/analytics/FirebaseAnalytics;J)V
 }
 
 public final class dev/gitlive/firebase/analytics/FirebaseAnalytics {
@@ -19,7 +20,7 @@ public final class dev/gitlive/firebase/analytics/FirebaseAnalytics {
 	public final fun setAnalyticsCollectionEnabled (Z)V
 	public final fun setConsent (Ljava/util/Map;)V
 	public final fun setDefaultEventParameters (Ljava/util/Map;)V
-	public final fun setSessionTimeoutInterval (J)V
+	public final fun setSessionTimeoutInterval-LRDsOJo (J)V
 	public final fun setUserId (Ljava/lang/String;)V
 	public final fun setUserProperty (Ljava/lang/String;Ljava/lang/String;)V
 }

--- a/firebase-analytics/api/jvm/firebase-analytics.api
+++ b/firebase-analytics/api/jvm/firebase-analytics.api
@@ -7,6 +7,7 @@ public final class dev/gitlive/firebase/analytics/AnalyticEventConstantsKt {
 public final class dev/gitlive/firebase/analytics/AnalyticsKt {
 	public static final fun logEvent (Ldev/gitlive/firebase/analytics/FirebaseAnalytics;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public static final fun setConsent (Ldev/gitlive/firebase/analytics/FirebaseAnalytics;Lkotlin/jvm/functions/Function1;)V
+	public static final fun setSessionTimeoutInterval (Ldev/gitlive/firebase/analytics/FirebaseAnalytics;J)V
 }
 
 public final class dev/gitlive/firebase/analytics/Analytics_jvmKt {
@@ -23,7 +24,7 @@ public final class dev/gitlive/firebase/analytics/FirebaseAnalytics {
 	public final fun setAnalyticsCollectionEnabled (Z)V
 	public final fun setConsent (Ljava/util/Map;)V
 	public final fun setDefaultEventParameters (Ljava/util/Map;)V
-	public final fun setSessionTimeoutInterval (J)V
+	public final fun setSessionTimeoutInterval-LRDsOJo (J)V
 	public final fun setUserId (Ljava/lang/String;)V
 	public final fun setUserProperty (Ljava/lang/String;Ljava/lang/String;)V
 }

--- a/firebase-analytics/src/androidMain/kotlin/dev/gitlive/firebase/analytics/analytics.kt
+++ b/firebase-analytics/src/androidMain/kotlin/dev/gitlive/firebase/analytics/analytics.kt
@@ -8,6 +8,7 @@ import com.google.firebase.analytics.setConsent
 import dev.gitlive.firebase.Firebase
 import dev.gitlive.firebase.FirebaseApp
 import kotlinx.coroutines.tasks.await
+import kotlin.time.Duration
 
 public actual val Firebase.analytics: FirebaseAnalytics
     get() = FirebaseAnalytics(com.google.firebase.Firebase.analytics)
@@ -36,8 +37,8 @@ public actual class FirebaseAnalytics(public val android: com.google.firebase.an
         android.setAnalyticsCollectionEnabled(enabled)
     }
 
-    public actual fun setSessionTimeoutInterval(sessionTimeoutInterval: Long) {
-        android.setSessionTimeoutDuration(sessionTimeoutInterval)
+    public actual fun setSessionTimeoutInterval(sessionTimeoutInterval: Duration) {
+        android.setSessionTimeoutDuration(sessionTimeoutInterval.inWholeMilliseconds)
     }
 
     public actual suspend fun getSessionId(): Long? = android.sessionId.await()

--- a/firebase-analytics/src/commonMain/kotlin/dev/gitlive/firebase/analytics/analytics.kt
+++ b/firebase-analytics/src/commonMain/kotlin/dev/gitlive/firebase/analytics/analytics.kt
@@ -2,6 +2,8 @@ package dev.gitlive.firebase.analytics
 
 import dev.gitlive.firebase.Firebase
 import dev.gitlive.firebase.FirebaseApp
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 
 public expect val Firebase.analytics: FirebaseAnalytics
 
@@ -13,7 +15,7 @@ public expect class FirebaseAnalytics {
     public fun setUserProperty(name: String, value: String)
     public fun setUserId(id: String)
     public fun setAnalyticsCollectionEnabled(enabled: Boolean)
-    public fun setSessionTimeoutInterval(sessionTimeoutInterval: Long)
+    public fun setSessionTimeoutInterval(sessionTimeoutInterval: Duration)
     public suspend fun getSessionId(): Long?
     public fun resetAnalyticsData()
     public fun setDefaultEventParameters(parameters: Map<String, String>)
@@ -30,6 +32,11 @@ public expect class FirebaseAnalytics {
         GRANTED,
         DENIED,
     }
+}
+
+@Deprecated("Use Kotlin Duration", replaceWith = ReplaceWith("setSessionTimeoutInterval(sessionTimeoutInterval.milliseconds)"))
+public fun FirebaseAnalytics.setSessionTimeoutInterval(sessionTimeoutInterval: Long) {
+    setSessionTimeoutInterval(sessionTimeoutInterval.milliseconds)
 }
 
 public fun FirebaseAnalytics.setConsent(builder: FirebaseAnalyticsConsentBuilder.() -> Unit) {

--- a/firebase-analytics/src/iosMain/kotlin/dev/gitlive/firebase/analytics/analytics.kt
+++ b/firebase-analytics/src/iosMain/kotlin/dev/gitlive/firebase/analytics/analytics.kt
@@ -7,6 +7,8 @@ import dev.gitlive.firebase.FirebaseApp
 import dev.gitlive.firebase.FirebaseException
 import kotlinx.coroutines.CompletableDeferred
 import platform.Foundation.NSError
+import kotlin.time.Duration
+import kotlin.time.DurationUnit
 
 public actual val Firebase.analytics: FirebaseAnalytics
     get() = FirebaseAnalytics(FIRAnalytics)
@@ -32,8 +34,8 @@ public actual class FirebaseAnalytics(public val ios: FIRAnalytics.Companion) {
         ios.setAnalyticsCollectionEnabled(enabled)
     }
 
-    public actual fun setSessionTimeoutInterval(sessionTimeoutInterval: Long) {
-        ios.setSessionTimeoutInterval(sessionTimeoutInterval.toDouble())
+    public actual fun setSessionTimeoutInterval(sessionTimeoutInterval: Duration) {
+        ios.setSessionTimeoutInterval(sessionTimeoutInterval.toDouble(DurationUnit.SECONDS))
     }
 
     public actual suspend fun getSessionId(): Long? = ios.awaitResult { sessionIDWithCompletion(it) }

--- a/firebase-analytics/src/jsMain/kotlin/dev/gitlive/firebase/analytics/analytics.kt
+++ b/firebase-analytics/src/jsMain/kotlin/dev/gitlive/firebase/analytics/analytics.kt
@@ -5,6 +5,7 @@ import dev.gitlive.firebase.FirebaseApp
 import dev.gitlive.firebase.FirebaseException
 import dev.gitlive.firebase.analytics.externals.getAnalytics
 import kotlinx.coroutines.await
+import kotlin.time.Duration
 
 public actual val Firebase.analytics: FirebaseAnalytics
     get() = FirebaseAnalytics(getAnalytics())
@@ -32,8 +33,8 @@ public actual class FirebaseAnalytics(public val js: dev.gitlive.firebase.analyt
         dev.gitlive.firebase.analytics.externals.setAnalyticsCollectionEnabled(js, enabled)
     }
 
-    public actual fun setSessionTimeoutInterval(sessionTimeoutInterval: Long) {
-        dev.gitlive.firebase.analytics.externals.setSessionTimeoutInterval(js, sessionTimeoutInterval)
+    public actual fun setSessionTimeoutInterval(sessionTimeoutInterval: Duration) {
+        dev.gitlive.firebase.analytics.externals.setSessionTimeoutInterval(js, sessionTimeoutInterval.inWholeMilliseconds)
     }
 
     public actual suspend fun getSessionId(): Long? = rethrow { dev.gitlive.firebase.analytics.externals.getSessionId(js).await() }

--- a/firebase-analytics/src/jvmMain/kotlin/dev/gitlive/firebase/analytics/analytics.jvm.kt
+++ b/firebase-analytics/src/jvmMain/kotlin/dev/gitlive/firebase/analytics/analytics.jvm.kt
@@ -3,6 +3,7 @@ package dev.gitlive.firebase.analytics
 import dev.gitlive.firebase.Firebase
 import dev.gitlive.firebase.FirebaseApp
 import dev.gitlive.firebase.FirebaseException
+import kotlin.time.Duration
 
 public actual val Firebase.analytics: FirebaseAnalytics
     get() = TODO("Not yet implemented")
@@ -16,7 +17,7 @@ public actual class FirebaseAnalytics {
     public actual fun setUserId(id: String) {}
     public actual fun resetAnalyticsData() {}
     public actual fun setAnalyticsCollectionEnabled(enabled: Boolean) {}
-    public actual fun setSessionTimeoutInterval(sessionTimeoutInterval: Long) {}
+    public actual fun setSessionTimeoutInterval(sessionTimeoutInterval: Duration) {}
     public actual suspend fun getSessionId(): Long? = TODO("Not yet implemented")
     public actual fun setDefaultEventParameters(parameters: Map<String, String>) {}
     public actual fun logEvent(name: String, parameters: Map<String, Any>?) {}

--- a/firebase-config/api/android/firebase-config.api
+++ b/firebase-config/api/android/firebase-config.api
@@ -11,8 +11,8 @@ public final class dev/gitlive/firebase/remoteconfig/FetchStatus : java/lang/Enu
 public final class dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfig {
 	public final fun activate (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun ensureInitialized (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun fetch (Ljava/lang/Long;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun fetch$default (Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfig;Ljava/lang/Long;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun fetch-dnQKTGw (Lkotlin/time/Duration;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun fetch-dnQKTGw$default (Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfig;Lkotlin/time/Duration;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun fetchAndActivate (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getAll ()Ljava/util/Map;
 	public final fun getAndroid ()Lcom/google/firebase/remoteconfig/FirebaseRemoteConfig;
@@ -25,33 +25,41 @@ public final class dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfig {
 }
 
 public final class dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigInfo {
-	public fun <init> (Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;JLdev/gitlive/firebase/remoteconfig/FetchStatus;)V
+	public synthetic fun <init> (Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;JLdev/gitlive/firebase/remoteconfig/FetchStatus;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;
-	public final fun component2 ()J
+	public final fun component2-UwyO8pc ()J
 	public final fun component3 ()Ldev/gitlive/firebase/remoteconfig/FetchStatus;
-	public final fun copy (Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;JLdev/gitlive/firebase/remoteconfig/FetchStatus;)Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigInfo;
-	public static synthetic fun copy$default (Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigInfo;Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;JLdev/gitlive/firebase/remoteconfig/FetchStatus;ILjava/lang/Object;)Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigInfo;
+	public final fun copy-8Mi8wO0 (Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;JLdev/gitlive/firebase/remoteconfig/FetchStatus;)Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigInfo;
+	public static synthetic fun copy-8Mi8wO0$default (Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigInfo;Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;JLdev/gitlive/firebase/remoteconfig/FetchStatus;ILjava/lang/Object;)Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigInfo;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getConfigSettings ()Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;
+	public final fun getFetchTime-UwyO8pc ()J
 	public final fun getFetchTimeMillis ()J
 	public final fun getLastFetchStatus ()Ldev/gitlive/firebase/remoteconfig/FetchStatus;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigKt {
+	public static final fun fetch (Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfig;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public final class dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings {
-	public fun <init> ()V
-	public fun <init> (JJ)V
 	public synthetic fun <init> (JJILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()J
-	public final fun component2 ()J
-	public final fun copy (JJ)Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;
-	public static synthetic fun copy$default (Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;JJILjava/lang/Object;)Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;
+	public synthetic fun <init> (JJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-UwyO8pc ()J
+	public final fun component2-UwyO8pc ()J
+	public final fun copy-QTBD994 (JJ)Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;
+	public static synthetic fun copy-QTBD994$default (Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;JJILjava/lang/Object;)Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFetchTimeout-UwyO8pc ()J
 	public final fun getFetchTimeoutInSeconds ()J
+	public final fun getMinimumFetchInterval-UwyO8pc ()J
 	public final fun getMinimumFetchIntervalInSeconds ()J
 	public fun hashCode ()I
+	public final fun setFetchTimeout-LRDsOJo (J)V
 	public final fun setFetchTimeoutInSeconds (J)V
+	public final fun setMinimumFetchInterval-LRDsOJo (J)V
 	public final fun setMinimumFetchIntervalInSeconds (J)V
 	public fun toString ()Ljava/lang/String;
 }

--- a/firebase-config/api/android/firebase-config.api
+++ b/firebase-config/api/android/firebase-config.api
@@ -25,15 +25,15 @@ public final class dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfig {
 }
 
 public final class dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigInfo {
-	public synthetic fun <init> (Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;JLdev/gitlive/firebase/remoteconfig/FetchStatus;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;Lkotlinx/datetime/Instant;Ldev/gitlive/firebase/remoteconfig/FetchStatus;)V
 	public final fun component1 ()Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;
-	public final fun component2-UwyO8pc ()J
+	public final fun component2 ()Lkotlinx/datetime/Instant;
 	public final fun component3 ()Ldev/gitlive/firebase/remoteconfig/FetchStatus;
-	public final fun copy-8Mi8wO0 (Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;JLdev/gitlive/firebase/remoteconfig/FetchStatus;)Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigInfo;
-	public static synthetic fun copy-8Mi8wO0$default (Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigInfo;Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;JLdev/gitlive/firebase/remoteconfig/FetchStatus;ILjava/lang/Object;)Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigInfo;
+	public final fun copy (Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;Lkotlinx/datetime/Instant;Ldev/gitlive/firebase/remoteconfig/FetchStatus;)Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigInfo;
+	public static synthetic fun copy$default (Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigInfo;Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;Lkotlinx/datetime/Instant;Ldev/gitlive/firebase/remoteconfig/FetchStatus;ILjava/lang/Object;)Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigInfo;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getConfigSettings ()Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;
-	public final fun getFetchTime-UwyO8pc ()J
+	public final fun getFetchTime ()Lkotlinx/datetime/Instant;
 	public final fun getFetchTimeMillis ()J
 	public final fun getLastFetchStatus ()Ldev/gitlive/firebase/remoteconfig/FetchStatus;
 	public fun hashCode ()I

--- a/firebase-config/api/jvm/firebase-config.api
+++ b/firebase-config/api/jvm/firebase-config.api
@@ -11,8 +11,8 @@ public final class dev/gitlive/firebase/remoteconfig/FetchStatus : java/lang/Enu
 public final class dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfig {
 	public final fun activate (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun ensureInitialized (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun fetch (Ljava/lang/Long;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun fetch$default (Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfig;Ljava/lang/Long;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun fetch-dnQKTGw (Lkotlin/time/Duration;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun fetch-dnQKTGw$default (Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfig;Lkotlin/time/Duration;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun fetchAndActivate (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getAll ()Ljava/util/Map;
 	public final fun getAndroid ()Lcom/google/firebase/remoteconfig/FirebaseRemoteConfig;
@@ -25,33 +25,41 @@ public final class dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfig {
 }
 
 public final class dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigInfo {
-	public fun <init> (Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;JLdev/gitlive/firebase/remoteconfig/FetchStatus;)V
+	public synthetic fun <init> (Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;JLdev/gitlive/firebase/remoteconfig/FetchStatus;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;
-	public final fun component2 ()J
+	public final fun component2-UwyO8pc ()J
 	public final fun component3 ()Ldev/gitlive/firebase/remoteconfig/FetchStatus;
-	public final fun copy (Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;JLdev/gitlive/firebase/remoteconfig/FetchStatus;)Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigInfo;
-	public static synthetic fun copy$default (Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigInfo;Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;JLdev/gitlive/firebase/remoteconfig/FetchStatus;ILjava/lang/Object;)Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigInfo;
+	public final fun copy-8Mi8wO0 (Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;JLdev/gitlive/firebase/remoteconfig/FetchStatus;)Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigInfo;
+	public static synthetic fun copy-8Mi8wO0$default (Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigInfo;Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;JLdev/gitlive/firebase/remoteconfig/FetchStatus;ILjava/lang/Object;)Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigInfo;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getConfigSettings ()Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;
+	public final fun getFetchTime-UwyO8pc ()J
 	public final fun getFetchTimeMillis ()J
 	public final fun getLastFetchStatus ()Ldev/gitlive/firebase/remoteconfig/FetchStatus;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigKt {
+	public static final fun fetch (Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfig;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public final class dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings {
-	public fun <init> ()V
-	public fun <init> (JJ)V
 	public synthetic fun <init> (JJILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()J
-	public final fun component2 ()J
-	public final fun copy (JJ)Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;
-	public static synthetic fun copy$default (Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;JJILjava/lang/Object;)Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;
+	public synthetic fun <init> (JJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-UwyO8pc ()J
+	public final fun component2-UwyO8pc ()J
+	public final fun copy-QTBD994 (JJ)Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;
+	public static synthetic fun copy-QTBD994$default (Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;JJILjava/lang/Object;)Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFetchTimeout-UwyO8pc ()J
 	public final fun getFetchTimeoutInSeconds ()J
+	public final fun getMinimumFetchInterval-UwyO8pc ()J
 	public final fun getMinimumFetchIntervalInSeconds ()J
 	public fun hashCode ()I
+	public final fun setFetchTimeout-LRDsOJo (J)V
 	public final fun setFetchTimeoutInSeconds (J)V
+	public final fun setMinimumFetchInterval-LRDsOJo (J)V
 	public final fun setMinimumFetchIntervalInSeconds (J)V
 	public fun toString ()Ljava/lang/String;
 }

--- a/firebase-config/api/jvm/firebase-config.api
+++ b/firebase-config/api/jvm/firebase-config.api
@@ -25,15 +25,15 @@ public final class dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfig {
 }
 
 public final class dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigInfo {
-	public synthetic fun <init> (Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;JLdev/gitlive/firebase/remoteconfig/FetchStatus;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;Lkotlinx/datetime/Instant;Ldev/gitlive/firebase/remoteconfig/FetchStatus;)V
 	public final fun component1 ()Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;
-	public final fun component2-UwyO8pc ()J
+	public final fun component2 ()Lkotlinx/datetime/Instant;
 	public final fun component3 ()Ldev/gitlive/firebase/remoteconfig/FetchStatus;
-	public final fun copy-8Mi8wO0 (Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;JLdev/gitlive/firebase/remoteconfig/FetchStatus;)Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigInfo;
-	public static synthetic fun copy-8Mi8wO0$default (Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigInfo;Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;JLdev/gitlive/firebase/remoteconfig/FetchStatus;ILjava/lang/Object;)Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigInfo;
+	public final fun copy (Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;Lkotlinx/datetime/Instant;Ldev/gitlive/firebase/remoteconfig/FetchStatus;)Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigInfo;
+	public static synthetic fun copy$default (Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigInfo;Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;Lkotlinx/datetime/Instant;Ldev/gitlive/firebase/remoteconfig/FetchStatus;ILjava/lang/Object;)Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigInfo;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getConfigSettings ()Ldev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings;
-	public final fun getFetchTime-UwyO8pc ()J
+	public final fun getFetchTime ()Lkotlinx/datetime/Instant;
 	public final fun getFetchTimeMillis ()J
 	public final fun getLastFetchStatus ()Ldev/gitlive/firebase/remoteconfig/FetchStatus;
 	public fun hashCode ()I

--- a/firebase-config/build.gradle.kts
+++ b/firebase-config/build.gradle.kts
@@ -29,6 +29,7 @@ android {
     }
 
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
@@ -42,6 +43,10 @@ android {
     lint {
         abortOnError = false
     }
+}
+
+dependencies {
+    coreLibraryDesugaring(libs.android.desugarjdk)
 }
 
 val supportIosTarget = project.property("skipIosTarget") != "true"
@@ -120,6 +125,7 @@ kotlin {
             dependencies {
                 api(project(":firebase-app"))
                 implementation(project(":firebase-common"))
+                api(libs.kotlinx.datetime)
             }
         }
 

--- a/firebase-config/src/androidMain/kotlin/dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfig.kt
+++ b/firebase-config/src/androidMain/kotlin/dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfig.kt
@@ -8,8 +8,8 @@ import com.google.firebase.remoteconfig.FirebaseRemoteConfigServerException
 import dev.gitlive.firebase.Firebase
 import dev.gitlive.firebase.FirebaseApp
 import kotlinx.coroutines.tasks.await
+import kotlinx.datetime.Instant
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig as AndroidFirebaseRemoteConfig
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigInfo as AndroidFirebaseRemoteConfigInfo
@@ -31,8 +31,8 @@ public actual class FirebaseRemoteConfig internal constructor(public val android
     public actual suspend fun settings(init: FirebaseRemoteConfigSettings.() -> Unit) {
         val settings = FirebaseRemoteConfigSettings().apply(init)
         val androidSettings = com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings.Builder()
-            .setMinimumFetchIntervalInSeconds(settings.minimumFetchIntervalInSeconds)
-            .setFetchTimeoutInSeconds(settings.fetchTimeoutInSeconds)
+            .setMinimumFetchIntervalInSeconds(settings.minimumFetchInterval.inWholeSeconds)
+            .setFetchTimeoutInSeconds(settings.fetchTimeout.inWholeSeconds)
             .build()
         android.setConfigSettingsAsync(androidSettings).await()
     }
@@ -74,7 +74,7 @@ public actual class FirebaseRemoteConfig internal constructor(public val android
 
         return FirebaseRemoteConfigInfo(
             configSettings = configSettings.asCommon(),
-            fetchTime = fetchTimeMillis.milliseconds,
+            fetchTime = Instant.fromEpochMilliseconds(fetchTimeMillis),
             lastFetchStatus = lastFetchStatus,
         )
     }

--- a/firebase-config/src/androidMain/kotlin/dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfig.kt
+++ b/firebase-config/src/androidMain/kotlin/dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfig.kt
@@ -8,6 +8,9 @@ import com.google.firebase.remoteconfig.FirebaseRemoteConfigServerException
 import dev.gitlive.firebase.Firebase
 import dev.gitlive.firebase.FirebaseApp
 import kotlinx.coroutines.tasks.await
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig as AndroidFirebaseRemoteConfig
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigInfo as AndroidFirebaseRemoteConfigInfo
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings as AndroidFirebaseRemoteConfigSettings
@@ -38,9 +41,9 @@ public actual class FirebaseRemoteConfig internal constructor(public val android
         android.setDefaultsAsync(defaults.toMap()).await()
     }
 
-    public actual suspend fun fetch(minimumFetchIntervalInSeconds: Long?) {
-        minimumFetchIntervalInSeconds
-            ?.also { android.fetch(it).await() }
+    public actual suspend fun fetch(minimumFetchInterval: Duration?) {
+        minimumFetchInterval
+            ?.also { android.fetch(it.inWholeSeconds).await() }
             ?: run { android.fetch().await() }
     }
 
@@ -56,8 +59,8 @@ public actual class FirebaseRemoteConfig internal constructor(public val android
     }
 
     private fun AndroidFirebaseRemoteConfigSettings.asCommon(): FirebaseRemoteConfigSettings = FirebaseRemoteConfigSettings(
-        fetchTimeoutInSeconds = fetchTimeoutInSeconds,
-        minimumFetchIntervalInSeconds = minimumFetchIntervalInSeconds,
+        fetchTimeout = fetchTimeoutInSeconds.seconds,
+        minimumFetchInterval = minimumFetchIntervalInSeconds.seconds,
     )
 
     private fun AndroidFirebaseRemoteConfigInfo.asCommon(): FirebaseRemoteConfigInfo {
@@ -71,7 +74,7 @@ public actual class FirebaseRemoteConfig internal constructor(public val android
 
         return FirebaseRemoteConfigInfo(
             configSettings = configSettings.asCommon(),
-            fetchTimeMillis = fetchTimeMillis,
+            fetchTime = fetchTimeMillis.milliseconds,
             lastFetchStatus = lastFetchStatus,
         )
     }

--- a/firebase-config/src/commonMain/kotlin/dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfig.kt
+++ b/firebase-config/src/commonMain/kotlin/dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfig.kt
@@ -3,6 +3,8 @@ package dev.gitlive.firebase.remoteconfig
 import dev.gitlive.firebase.Firebase
 import dev.gitlive.firebase.FirebaseApp
 import dev.gitlive.firebase.FirebaseException
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 /** Returns the [FirebaseRemoteConfig] instance of the default [FirebaseApp]. */
 public expect val Firebase.remoteConfig: FirebaseRemoteConfig
@@ -63,10 +65,10 @@ public expect class FirebaseRemoteConfig {
      * after deletion will create a new installation ID for this Firebase installation and resume the
      * periodic sync.
      *
-     * @param minimumFetchIntervalInSeconds If configs in the local storage were fetched more than
-     *     this many seconds ago, configs are served from the backend instead of local storage.
+     * @param minimumFetchInterval If configs in the local storage were fetched more than
+     *     this long ago (rounded down to seconds), configs are served from the backend instead of local storage.
      */
-    public suspend fun fetch(minimumFetchIntervalInSeconds: Long? = null)
+    public suspend fun fetch(minimumFetchInterval: Duration? = null)
 
     /**
      * Asynchronously fetches and then activates the fetched configs.
@@ -126,6 +128,11 @@ public expect class FirebaseRemoteConfig {
      *     keys and values.
      */
     public suspend fun setDefaults(vararg defaults: Pair<String, Any?>)
+}
+
+@Deprecated("Replaced with Kotlin Duration", replaceWith = ReplaceWith("fetch(minimumFetchIntervalInSeconds.seconds)"))
+public suspend fun FirebaseRemoteConfig.fetch(minimumFetchIntervalInSeconds: Long) {
+    fetch(minimumFetchIntervalInSeconds.seconds)
 }
 
 @Suppress("IMPLICIT_CAST_TO_ANY")

--- a/firebase-config/src/commonMain/kotlin/dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigInfo.kt
+++ b/firebase-config/src/commonMain/kotlin/dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigInfo.kt
@@ -1,5 +1,7 @@
 package dev.gitlive.firebase.remoteconfig
 
+import kotlin.time.Duration
+
 /** Wraps the current state of the [FirebaseRemoteConfig] singleton object. */
 public data class FirebaseRemoteConfigInfo(
     /**
@@ -10,13 +12,13 @@ public data class FirebaseRemoteConfigInfo(
     val configSettings: FirebaseRemoteConfigSettings,
 
     /**
-     * Gets the timestamp (milliseconds since epoch) of the last successful fetch, regardless of
+     * Gets the timestamp ([Duration] since epoch) of the last successful fetch, regardless of
      * whether the fetch was activated or not.
      *
-     * @return -1 if no fetch attempt has been made yet. Otherwise, returns the timestamp of the last
+     * @return `-1.milliseconds` if no fetch attempt has been made yet. Otherwise, returns the timestamp of the last
      *     successful fetch operation.
      */
-    val fetchTimeMillis: Long,
+    val fetchTime: Duration,
 
     /**
      * Gets the status of the most recent fetch attempt.
@@ -24,7 +26,10 @@ public data class FirebaseRemoteConfigInfo(
      * @return Will return one of [FetchStatus.Success], [FetchStatus.Failure], [FetchStatus.Throttled], or [FetchStatus.NoFetchYet]
      */
     val lastFetchStatus: FetchStatus,
-)
+) {
+    @Deprecated("Replaced with Kotlin Duration", replaceWith = ReplaceWith("fetchTime"))
+    val fetchTimeMillis: Long get() = fetchTime.inWholeMilliseconds
+}
 
 public enum class FetchStatus {
     /**

--- a/firebase-config/src/commonMain/kotlin/dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigInfo.kt
+++ b/firebase-config/src/commonMain/kotlin/dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigInfo.kt
@@ -1,6 +1,6 @@
 package dev.gitlive.firebase.remoteconfig
 
-import kotlin.time.Duration
+import kotlinx.datetime.Instant
 
 /** Wraps the current state of the [FirebaseRemoteConfig] singleton object. */
 public data class FirebaseRemoteConfigInfo(
@@ -12,13 +12,13 @@ public data class FirebaseRemoteConfigInfo(
     val configSettings: FirebaseRemoteConfigSettings,
 
     /**
-     * Gets the timestamp ([Duration] since epoch) of the last successful fetch, regardless of
+     * Gets the [Instant] of the last successful fetch, regardless of
      * whether the fetch was activated or not.
      *
-     * @return `-1.milliseconds` if no fetch attempt has been made yet. Otherwise, returns the timestamp of the last
+     * @return `Instant.fromEpochMilliseconds(-1)` if no fetch attempt has been made yet. Otherwise, returns the timestamp of the last
      *     successful fetch operation.
      */
-    val fetchTime: Duration,
+    val fetchTime: Instant,
 
     /**
      * Gets the status of the most recent fetch attempt.
@@ -28,7 +28,7 @@ public data class FirebaseRemoteConfigInfo(
     val lastFetchStatus: FetchStatus,
 ) {
     @Deprecated("Replaced with Kotlin Duration", replaceWith = ReplaceWith("fetchTime"))
-    val fetchTimeMillis: Long get() = fetchTime.inWholeMilliseconds
+    val fetchTimeMillis: Long get() = fetchTime.toEpochMilliseconds()
 }
 
 public enum class FetchStatus {

--- a/firebase-config/src/commonMain/kotlin/dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings.kt
+++ b/firebase-config/src/commonMain/kotlin/dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfigSettings.kt
@@ -1,9 +1,14 @@
 package dev.gitlive.firebase.remoteconfig
 
-private const val CONNECTION_TIMEOUT_IN_SECONDS = 60L
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+private val CONNECTION_TIMEOUT = 1.minutes
 
 // https://firebase.google.com/docs/remote-config/get-started?hl=en&platform=android#throttling
-private const val DEFAULT_FETCH_INTERVAL_IN_SECONDS = 12 * 3600L
+private val DEFAULT_FETCH_INTERVAL = 12.hours
 
 /** Wraps the settings for [FirebaseRemoteConfig] operations. */
 public data class FirebaseRemoteConfigSettings(
@@ -13,8 +18,23 @@ public data class FirebaseRemoteConfigSettings(
      * The timeout specifies how long the client should wait for a connection to the Firebase
      * Remote Config server.
      */
-    var fetchTimeoutInSeconds: Long = CONNECTION_TIMEOUT_IN_SECONDS,
+    var fetchTimeout: Duration = CONNECTION_TIMEOUT,
 
     /** Returns the minimum interval between successive fetches calls in seconds. */
-    var minimumFetchIntervalInSeconds: Long = DEFAULT_FETCH_INTERVAL_IN_SECONDS,
-)
+    var minimumFetchInterval: Duration = DEFAULT_FETCH_INTERVAL,
+) {
+
+    @Deprecated("Replaced with Kotlin Duration", replaceWith = ReplaceWith("fetchTimeout"))
+    public var fetchTimeoutInSeconds: Long
+        get() = fetchTimeout.inWholeSeconds
+        set(value) {
+            fetchTimeout = value.seconds
+        }
+
+    @Deprecated("Replaced with Kotlin Duration", replaceWith = ReplaceWith("minimumFetchInterval"))
+    public var minimumFetchIntervalInSeconds: Long
+        get() = minimumFetchInterval.inWholeSeconds
+        set(value) {
+            minimumFetchInterval = value.seconds
+        }
+}

--- a/firebase-config/src/commonTest/kotlin/dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfig.kt
+++ b/firebase-config/src/commonTest/kotlin/dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfig.kt
@@ -9,12 +9,12 @@ import dev.gitlive.firebase.FirebaseOptions
 import dev.gitlive.firebase.apps
 import dev.gitlive.firebase.initialize
 import dev.gitlive.firebase.runTest
+import kotlinx.datetime.Instant
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
@@ -104,7 +104,7 @@ class FirebaseRemoteConfigTest {
         assertEquals(
             FirebaseRemoteConfigInfo(
                 configSettings = FirebaseRemoteConfigSettings(),
-                fetchTime = (-1).milliseconds,
+                fetchTime = Instant.fromEpochMilliseconds(-1),
                 lastFetchStatus = FetchStatus.NoFetchYet,
             ).toString(),
             remoteConfig.info.toString(),

--- a/firebase-config/src/commonTest/kotlin/dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfig.kt
+++ b/firebase-config/src/commonTest/kotlin/dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfig.kt
@@ -14,6 +14,9 @@ import kotlin.test.BeforeTest
 import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
 expect val context: Any
 expect annotation class IgnoreForAndroidUnitTest()
@@ -101,7 +104,7 @@ class FirebaseRemoteConfigTest {
         assertEquals(
             FirebaseRemoteConfigInfo(
                 configSettings = FirebaseRemoteConfigSettings(),
-                fetchTimeMillis = -1,
+                fetchTime = (-1).milliseconds,
                 lastFetchStatus = FetchStatus.NoFetchYet,
             ).toString(),
             remoteConfig.info.toString(),
@@ -111,12 +114,12 @@ class FirebaseRemoteConfigTest {
     @Test
     fun testSetConfigSettings() = runTest {
         remoteConfig.settings {
-            fetchTimeoutInSeconds = 42
-            minimumFetchIntervalInSeconds = 42
+            fetchTimeout = 42.seconds
+            minimumFetchInterval = 42.seconds
         }
         val info = remoteConfig.info
-        assertEquals(42, info.configSettings.fetchTimeoutInSeconds)
-        assertEquals(42, info.configSettings.minimumFetchIntervalInSeconds)
+        assertEquals(42.seconds, info.configSettings.fetchTimeout)
+        assertEquals(42.seconds, info.configSettings.minimumFetchInterval)
     }
 
     // Unfortunately Firebase Remote Config is not implemented by Firebase emulator so it may be
@@ -126,7 +129,7 @@ class FirebaseRemoteConfigTest {
     @Ignore
     fun testFetch() = runTest {
         remoteConfig.settings {
-            minimumFetchIntervalInSeconds = 60
+            minimumFetchInterval = 1.minutes
         }
 
         remoteConfig.fetch()
@@ -141,7 +144,7 @@ class FirebaseRemoteConfigTest {
     @Ignore
     fun testFetchAndActivate() = runTest {
         remoteConfig.settings {
-            minimumFetchIntervalInSeconds = 60
+            minimumFetchInterval = 1.minutes
         }
 
         remoteConfig.fetchAndActivate()

--- a/firebase-config/src/iosMain/kotlin/dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfig.kt
+++ b/firebase-config/src/iosMain/kotlin/dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfig.kt
@@ -13,10 +13,10 @@ import dev.gitlive.firebase.FirebaseApp
 import dev.gitlive.firebase.FirebaseException
 import dev.gitlive.firebase.app
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.datetime.Instant
+import kotlinx.datetime.toKotlinInstant
 import platform.Foundation.NSError
-import platform.Foundation.timeIntervalSince1970
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.DurationUnit
 
@@ -45,10 +45,9 @@ public actual class FirebaseRemoteConfig internal constructor(public val ios: FI
         get() {
             return FirebaseRemoteConfigInfo(
                 configSettings = ios.configSettings.asCommon(),
-                fetchTime = ios.lastFetchTime
-                    ?.timeIntervalSince1970?.seconds
-                    ?.takeIf { it > Duration.ZERO }
-                    ?: (-1L).milliseconds,
+                fetchTime = ios.lastFetchTime?.toKotlinInstant()
+                    ?.takeIf { it.toEpochMilliseconds() > 0 }
+                    ?: Instant.fromEpochMilliseconds(-1),
                 lastFetchStatus = ios.lastFetchStatus.asCommon(),
             )
         }

--- a/firebase-config/src/iosMain/kotlin/dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfig.kt
+++ b/firebase-config/src/iosMain/kotlin/dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfig.kt
@@ -15,6 +15,10 @@ import dev.gitlive.firebase.app
 import kotlinx.coroutines.CompletableDeferred
 import platform.Foundation.NSError
 import platform.Foundation.timeIntervalSince1970
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.DurationUnit
 
 public actual val Firebase.remoteConfig: FirebaseRemoteConfig
     get() = FirebaseRemoteConfig(FIRRemoteConfig.remoteConfig())
@@ -41,11 +45,10 @@ public actual class FirebaseRemoteConfig internal constructor(public val ios: FI
         get() {
             return FirebaseRemoteConfigInfo(
                 configSettings = ios.configSettings.asCommon(),
-                fetchTimeMillis = ios.lastFetchTime
-                    ?.timeIntervalSince1970
-                    ?.let { it.toLong() * 1000 }
-                    ?.takeIf { it > 0 }
-                    ?: -1L,
+                fetchTime = ios.lastFetchTime
+                    ?.timeIntervalSince1970?.seconds
+                    ?.takeIf { it > Duration.ZERO }
+                    ?: (-1L).milliseconds,
                 lastFetchStatus = ios.lastFetchStatus.asCommon(),
             )
         }
@@ -55,10 +58,10 @@ public actual class FirebaseRemoteConfig internal constructor(public val ios: FI
     public actual suspend fun ensureInitialized(): Unit =
         ios.await { ensureInitializedWithCompletionHandler(it) }
 
-    public actual suspend fun fetch(minimumFetchIntervalInSeconds: Long?) {
-        if (minimumFetchIntervalInSeconds != null) {
+    public actual suspend fun fetch(minimumFetchInterval: Duration?) {
+        if (minimumFetchInterval != null) {
             ios.awaitResult<FIRRemoteConfig, FIRRemoteConfigFetchStatus> {
-                fetchWithExpirationDuration(minimumFetchIntervalInSeconds.toDouble(), it)
+                fetchWithExpirationDuration(minimumFetchInterval.toDouble(DurationUnit.SECONDS), it)
             }
         } else {
             ios.awaitResult { fetchWithCompletionHandler(it) }
@@ -85,8 +88,8 @@ public actual class FirebaseRemoteConfig internal constructor(public val ios: FI
     public actual suspend fun settings(init: FirebaseRemoteConfigSettings.() -> Unit) {
         val settings = FirebaseRemoteConfigSettings().apply(init)
         val iosSettings = FIRRemoteConfigSettings().apply {
-            minimumFetchInterval = settings.minimumFetchIntervalInSeconds.toDouble()
-            fetchTimeout = settings.fetchTimeoutInSeconds.toDouble()
+            minimumFetchInterval = settings.minimumFetchInterval.toDouble(DurationUnit.SECONDS)
+            fetchTimeout = settings.fetchTimeout.toDouble(DurationUnit.SECONDS)
         }
         ios.setConfigSettings(iosSettings)
     }
@@ -96,8 +99,8 @@ public actual class FirebaseRemoteConfig internal constructor(public val ios: FI
     }
 
     private fun FIRRemoteConfigSettings.asCommon(): FirebaseRemoteConfigSettings = FirebaseRemoteConfigSettings(
-        fetchTimeoutInSeconds = fetchTimeout.toLong(),
-        minimumFetchIntervalInSeconds = minimumFetchInterval.toLong(),
+        fetchTimeout = fetchTimeout.seconds,
+        minimumFetchInterval = minimumFetchInterval.seconds,
     )
 
     private fun FIRRemoteConfigFetchStatus.asCommon(): FetchStatus = when (this) {

--- a/firebase-config/src/jsMain/kotlin/dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfig.kt
+++ b/firebase-config/src/jsMain/kotlin/dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfig.kt
@@ -5,6 +5,7 @@ import dev.gitlive.firebase.FirebaseApp
 import dev.gitlive.firebase.FirebaseException
 import dev.gitlive.firebase.remoteconfig.externals.*
 import kotlinx.coroutines.await
+import kotlinx.datetime.Instant
 import kotlin.js.json
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -24,7 +25,7 @@ public actual class FirebaseRemoteConfig internal constructor(public val js: Rem
         get() = rethrow {
             FirebaseRemoteConfigInfo(
                 configSettings = js.settings.toFirebaseRemoteConfigSettings(),
-                fetchTime = js.fetchTimeMillis.milliseconds,
+                fetchTime = Instant.fromEpochMilliseconds(js.fetchTimeMillis.toLong()),
                 lastFetchStatus = js.lastFetchStatus.toFetchStatus(),
             )
         }

--- a/firebase-config/src/jsMain/kotlin/dev/gitlive/firebase/remoteconfig/externals/remoteconfig.kt
+++ b/firebase-config/src/jsMain/kotlin/dev/gitlive/firebase/remoteconfig/externals/remoteconfig.kt
@@ -29,7 +29,7 @@ public external fun getValue(remoteConfig: RemoteConfig, key: String): Value
 
 public external interface RemoteConfig {
     public var defaultConfig: Any
-    public var fetchTimeMillis: Long
+    public var fetchTimeMillis: Double
     public var lastFetchStatus: String
     public val settings: Settings
 }

--- a/firebase-firestore/src/commonTest/kotlin/dev/gitlive/firebase/firestore/FirestoreSourceTest.kt
+++ b/firebase-firestore/src/commonTest/kotlin/dev/gitlive/firebase/firestore/FirestoreSourceTest.kt
@@ -7,6 +7,7 @@ import kotlin.test.*
  * These tests are separated from other tests because
  * testing Firestore Source requires toggling persistence settings per test.
  */
+@IgnoreForAndroidUnitTest
 class FirestoreSourceTest {
     lateinit var firestore: FirebaseFirestore
 

--- a/firebase-firestore/src/commonTest/kotlin/dev/gitlive/firebase/firestore/firestore.kt
+++ b/firebase-firestore/src/commonTest/kotlin/dev/gitlive/firebase/firestore/firestore.kt
@@ -32,6 +32,8 @@ import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 
 expect val emulatorHost: String
 expect val context: Any
@@ -216,7 +218,7 @@ class FirebaseFirestoreTest {
         val deferredPendingWritesSnapshot = async {
             doc.snapshots.filter { it.exists }.first()
         }
-        nonSkippedDelay(100) // makes possible to catch pending writes snapshot
+        nonSkippedDelay(100.milliseconds) // makes possible to catch pending writes snapshot
 
         doc.set(
             FirestoreTimeTest.serializer(),
@@ -256,7 +258,7 @@ class FirebaseFirestoreTest {
         val deferredPendingWritesSnapshot = async {
             doc.snapshots.filter { it.exists }.first()
         }
-        nonSkippedDelay(100) // makes possible to catch pending writes snapshot
+        nonSkippedDelay(100.milliseconds) // makes possible to catch pending writes snapshot
 
         doc.set(FirestoreTimeTest.serializer(), FirestoreTimeTest("ServerTimestampBehavior", Timestamp.ServerTimestamp))
 
@@ -275,7 +277,7 @@ class FirebaseFirestoreTest {
         val deferredPendingWritesSnapshot = async {
             doc.snapshots.filter { it.exists }.first()
         }
-        nonSkippedDelay(100) // makes possible to catch pending writes snapshot
+        nonSkippedDelay(100.milliseconds) // makes possible to catch pending writes snapshot
 
         doc.set(FirestoreTimeTest.serializer(), FirestoreTimeTest("ServerTimestampBehavior", Timestamp.ServerTimestamp))
 
@@ -595,7 +597,7 @@ class FirebaseFirestoreTest {
         val deferredPendingWritesSnapshot = async {
             doc.snapshots.filter { it.exists }.first()
         }
-        nonSkippedDelay(100) // makes possible to catch pending writes snapshot
+        nonSkippedDelay(100.milliseconds) // makes possible to catch pending writes snapshot
 
         doc.set(DoubleTimestamp.serializer(), DoubleTimestamp(DoubleAsTimestampSerializer.SERVER_TIMESTAMP))
 
@@ -1053,7 +1055,7 @@ class FirebaseFirestoreTest {
         }
     }
 
-    private suspend fun nonSkippedDelay(timeout: Long) = withContext(Dispatchers.Default) {
+    private suspend fun nonSkippedDelay(timeout: Duration) = withContext(Dispatchers.Default) {
         delay(timeout)
     }
 }

--- a/firebase-functions/api/android/firebase-functions.api
+++ b/firebase-functions/api/android/firebase-functions.api
@@ -1,3 +1,12 @@
+public final class dev/gitlive/firebase/functions/AndroidFunctions {
+	public static final fun functions (Ldev/gitlive/firebase/Firebase;Ldev/gitlive/firebase/FirebaseApp;)Ldev/gitlive/firebase/functions/FirebaseFunctions;
+	public static final fun functions (Ldev/gitlive/firebase/Firebase;Ldev/gitlive/firebase/FirebaseApp;Ljava/lang/String;)Ldev/gitlive/firebase/functions/FirebaseFunctions;
+	public static final fun functions (Ldev/gitlive/firebase/Firebase;Ljava/lang/String;)Ldev/gitlive/firebase/functions/FirebaseFunctions;
+	public static final fun getCode (Lcom/google/firebase/functions/FirebaseFunctionsException;)Lcom/google/firebase/functions/FirebaseFunctionsException$Code;
+	public static final fun getDetails (Lcom/google/firebase/functions/FirebaseFunctionsException;)Ljava/lang/Object;
+	public static final fun getFunctions (Ldev/gitlive/firebase/Firebase;)Ldev/gitlive/firebase/functions/FirebaseFunctions;
+}
+
 public final class dev/gitlive/firebase/functions/FirebaseFunctions {
 	public final fun component1 ()Lcom/google/firebase/functions/FirebaseFunctions;
 	public final fun copy (Lcom/google/firebase/functions/FirebaseFunctions;)Ldev/gitlive/firebase/functions/FirebaseFunctions;
@@ -5,19 +14,14 @@ public final class dev/gitlive/firebase/functions/FirebaseFunctions {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAndroid ()Lcom/google/firebase/functions/FirebaseFunctions;
 	public fun hashCode ()I
-	public final fun httpsCallable (Ljava/lang/String;Ljava/lang/Long;)Ldev/gitlive/firebase/functions/HttpsCallableReference;
-	public static synthetic fun httpsCallable$default (Ldev/gitlive/firebase/functions/FirebaseFunctions;Ljava/lang/String;Ljava/lang/Long;ILjava/lang/Object;)Ldev/gitlive/firebase/functions/HttpsCallableReference;
+	public final fun httpsCallable-6Au4x4Y (Ljava/lang/String;Lkotlin/time/Duration;)Ldev/gitlive/firebase/functions/HttpsCallableReference;
+	public static synthetic fun httpsCallable-6Au4x4Y$default (Ldev/gitlive/firebase/functions/FirebaseFunctions;Ljava/lang/String;Lkotlin/time/Duration;ILjava/lang/Object;)Ldev/gitlive/firebase/functions/HttpsCallableReference;
 	public fun toString ()Ljava/lang/String;
 	public final fun useEmulator (Ljava/lang/String;I)V
 }
 
 public final class dev/gitlive/firebase/functions/FunctionsKt {
-	public static final fun functions (Ldev/gitlive/firebase/Firebase;Ldev/gitlive/firebase/FirebaseApp;)Ldev/gitlive/firebase/functions/FirebaseFunctions;
-	public static final fun functions (Ldev/gitlive/firebase/Firebase;Ldev/gitlive/firebase/FirebaseApp;Ljava/lang/String;)Ldev/gitlive/firebase/functions/FirebaseFunctions;
-	public static final fun functions (Ldev/gitlive/firebase/Firebase;Ljava/lang/String;)Ldev/gitlive/firebase/functions/FirebaseFunctions;
-	public static final fun getCode (Lcom/google/firebase/functions/FirebaseFunctionsException;)Lcom/google/firebase/functions/FirebaseFunctionsException$Code;
-	public static final fun getDetails (Lcom/google/firebase/functions/FirebaseFunctionsException;)Ljava/lang/Object;
-	public static final fun getFunctions (Ldev/gitlive/firebase/Firebase;)Ldev/gitlive/firebase/functions/FirebaseFunctions;
+	public static final fun httpsCallable (Ldev/gitlive/firebase/functions/FirebaseFunctions;Ljava/lang/String;J)Ldev/gitlive/firebase/functions/HttpsCallableReference;
 }
 
 public final class dev/gitlive/firebase/functions/HttpsCallableReference {

--- a/firebase-functions/api/jvm/firebase-functions.api
+++ b/firebase-functions/api/jvm/firebase-functions.api
@@ -1,3 +1,12 @@
+public final class dev/gitlive/firebase/functions/AndroidFunctions {
+	public static final fun functions (Ldev/gitlive/firebase/Firebase;Ldev/gitlive/firebase/FirebaseApp;)Ldev/gitlive/firebase/functions/FirebaseFunctions;
+	public static final fun functions (Ldev/gitlive/firebase/Firebase;Ldev/gitlive/firebase/FirebaseApp;Ljava/lang/String;)Ldev/gitlive/firebase/functions/FirebaseFunctions;
+	public static final fun functions (Ldev/gitlive/firebase/Firebase;Ljava/lang/String;)Ldev/gitlive/firebase/functions/FirebaseFunctions;
+	public static final fun getCode (Lcom/google/firebase/functions/FirebaseFunctionsException;)Lcom/google/firebase/functions/FirebaseFunctionsException$Code;
+	public static final fun getDetails (Lcom/google/firebase/functions/FirebaseFunctionsException;)Ljava/lang/Object;
+	public static final fun getFunctions (Ldev/gitlive/firebase/Firebase;)Ldev/gitlive/firebase/functions/FirebaseFunctions;
+}
+
 public final class dev/gitlive/firebase/functions/FirebaseFunctions {
 	public final fun component1 ()Lcom/google/firebase/functions/FirebaseFunctions;
 	public final fun copy (Lcom/google/firebase/functions/FirebaseFunctions;)Ldev/gitlive/firebase/functions/FirebaseFunctions;
@@ -5,19 +14,14 @@ public final class dev/gitlive/firebase/functions/FirebaseFunctions {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAndroid ()Lcom/google/firebase/functions/FirebaseFunctions;
 	public fun hashCode ()I
-	public final fun httpsCallable (Ljava/lang/String;Ljava/lang/Long;)Ldev/gitlive/firebase/functions/HttpsCallableReference;
-	public static synthetic fun httpsCallable$default (Ldev/gitlive/firebase/functions/FirebaseFunctions;Ljava/lang/String;Ljava/lang/Long;ILjava/lang/Object;)Ldev/gitlive/firebase/functions/HttpsCallableReference;
+	public final fun httpsCallable-6Au4x4Y (Ljava/lang/String;Lkotlin/time/Duration;)Ldev/gitlive/firebase/functions/HttpsCallableReference;
+	public static synthetic fun httpsCallable-6Au4x4Y$default (Ldev/gitlive/firebase/functions/FirebaseFunctions;Ljava/lang/String;Lkotlin/time/Duration;ILjava/lang/Object;)Ldev/gitlive/firebase/functions/HttpsCallableReference;
 	public fun toString ()Ljava/lang/String;
 	public final fun useEmulator (Ljava/lang/String;I)V
 }
 
 public final class dev/gitlive/firebase/functions/FunctionsKt {
-	public static final fun functions (Ldev/gitlive/firebase/Firebase;Ldev/gitlive/firebase/FirebaseApp;)Ldev/gitlive/firebase/functions/FirebaseFunctions;
-	public static final fun functions (Ldev/gitlive/firebase/Firebase;Ldev/gitlive/firebase/FirebaseApp;Ljava/lang/String;)Ldev/gitlive/firebase/functions/FirebaseFunctions;
-	public static final fun functions (Ldev/gitlive/firebase/Firebase;Ljava/lang/String;)Ldev/gitlive/firebase/functions/FirebaseFunctions;
-	public static final fun getCode (Lcom/google/firebase/functions/FirebaseFunctionsException;)Lcom/google/firebase/functions/FirebaseFunctionsException$Code;
-	public static final fun getDetails (Lcom/google/firebase/functions/FirebaseFunctionsException;)Ljava/lang/Object;
-	public static final fun getFunctions (Ldev/gitlive/firebase/Firebase;)Ldev/gitlive/firebase/functions/FirebaseFunctions;
+	public static final fun httpsCallable (Ldev/gitlive/firebase/functions/FirebaseFunctions;Ljava/lang/String;J)Ldev/gitlive/firebase/functions/HttpsCallableReference;
 }
 
 public final class dev/gitlive/firebase/functions/HttpsCallableReference {

--- a/firebase-functions/src/androidMain/kotlin/dev/gitlive/firebase/functions/functions.kt
+++ b/firebase-functions/src/androidMain/kotlin/dev/gitlive/firebase/functions/functions.kt
@@ -2,6 +2,8 @@
  * Copyright (c) 2020 GitLive Ltd.  Use of this source code is governed by the Apache 2.0 license.
  */
 
+@file:JvmName("AndroidFunctions")
+
 package dev.gitlive.firebase.functions
 
 import dev.gitlive.firebase.DecodeSettings
@@ -11,6 +13,7 @@ import dev.gitlive.firebase.internal.decode
 import kotlinx.coroutines.tasks.await
 import kotlinx.serialization.DeserializationStrategy
 import java.util.concurrent.TimeUnit
+import kotlin.time.Duration
 
 public actual val Firebase.functions: FirebaseFunctions
     get() = FirebaseFunctions(com.google.firebase.functions.FirebaseFunctions.getInstance())
@@ -25,8 +28,8 @@ public actual fun Firebase.functions(app: FirebaseApp, region: String): Firebase
     FirebaseFunctions(com.google.firebase.functions.FirebaseFunctions.getInstance(app.android, region))
 
 public actual data class FirebaseFunctions internal constructor(public val android: com.google.firebase.functions.FirebaseFunctions) {
-    public actual fun httpsCallable(name: String, timeout: Long?): HttpsCallableReference =
-        HttpsCallableReference(android.getHttpsCallable(name).apply { timeout?.let { setTimeout(it, TimeUnit.MILLISECONDS) } }.native)
+    public actual fun httpsCallable(name: String, timeout: Duration?): HttpsCallableReference =
+        HttpsCallableReference(android.getHttpsCallable(name).apply { timeout?.let { setTimeout(it.inWholeMilliseconds, TimeUnit.MILLISECONDS) } }.native)
 
     public actual fun useEmulator(host: String, port: Int) {
         android.useEmulator(host, port)

--- a/firebase-functions/src/commonMain/kotlin/dev/gitlive/firebase/functions/functions.kt
+++ b/firebase-functions/src/commonMain/kotlin/dev/gitlive/firebase/functions/functions.kt
@@ -12,11 +12,13 @@ import dev.gitlive.firebase.FirebaseException
 import dev.gitlive.firebase.internal.encode
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.SerializationStrategy
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 
 /** FirebaseFunctions lets you call Cloud Functions for Firebase. */
 public expect class FirebaseFunctions {
     /** Returns a reference to the callable HTTPS trigger with the given name. */
-    public fun httpsCallable(name: String, timeout: Long? = null): HttpsCallableReference
+    public fun httpsCallable(name: String, timeout: Duration? = null): HttpsCallableReference
 
     /**
      * Modifies this FirebaseFunctions instance to communicate with the Cloud Functions emulator.
@@ -28,6 +30,9 @@ public expect class FirebaseFunctions {
      */
     public fun useEmulator(host: String, port: Int)
 }
+
+@Deprecated("Replaced with Kotlin Duration", replaceWith = ReplaceWith("httpsCallable(name, timeout.milliseconds)"))
+public fun FirebaseFunctions.httpsCallable(name: String, timeout: Long): HttpsCallableReference = httpsCallable(name, timeout.milliseconds)
 
 @PublishedApi
 internal expect class NativeHttpsCallableReference {

--- a/firebase-functions/src/iosMain/kotlin/dev/gitlive/firebase/functions/functions.kt
+++ b/firebase-functions/src/iosMain/kotlin/dev/gitlive/firebase/functions/functions.kt
@@ -17,6 +17,8 @@ import dev.gitlive.firebase.internal.decode
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.serialization.DeserializationStrategy
 import platform.Foundation.NSError
+import kotlin.time.Duration
+import kotlin.time.DurationUnit
 
 public actual val Firebase.functions: FirebaseFunctions
     get() = FirebaseFunctions(FIRFunctions.functions())
@@ -36,8 +38,8 @@ public actual fun Firebase.functions(
 )
 
 public actual data class FirebaseFunctions internal constructor(public val ios: FIRFunctions) {
-    public actual fun httpsCallable(name: String, timeout: Long?): HttpsCallableReference =
-        HttpsCallableReference(ios.HTTPSCallableWithName(name).apply { timeout?.let { setTimeoutInterval(it / 1000.0) } }.native)
+    public actual fun httpsCallable(name: String, timeout: Duration?): HttpsCallableReference =
+        HttpsCallableReference(ios.HTTPSCallableWithName(name).apply { timeout?.let { setTimeoutInterval(it.toDouble(DurationUnit.SECONDS)) } }.native)
 
     public actual fun useEmulator(host: String, port: Int) {
         ios.useEmulatorWithHost(host, port.toLong())

--- a/firebase-functions/src/jsMain/kotlin/dev/gitlive/firebase/functions/functions.kt
+++ b/firebase-functions/src/jsMain/kotlin/dev/gitlive/firebase/functions/functions.kt
@@ -20,6 +20,8 @@ import dev.gitlive.firebase.internal.decode
 import kotlinx.coroutines.await
 import kotlinx.serialization.DeserializationStrategy
 import kotlin.js.json
+import kotlin.time.Duration
+import kotlin.time.DurationUnit
 import dev.gitlive.firebase.functions.externals.HttpsCallableResult as JsHttpsCallableResult
 
 public actual val Firebase.functions: FirebaseFunctions
@@ -35,8 +37,8 @@ public actual fun Firebase.functions(app: FirebaseApp, region: String): Firebase
     rethrow { FirebaseFunctions(getFunctions(app.js, region)) }
 
 public actual class FirebaseFunctions internal constructor(public val js: Functions) {
-    public actual fun httpsCallable(name: String, timeout: Long?): HttpsCallableReference =
-        rethrow { HttpsCallableReference(httpsCallable(js, name, timeout?.let { json("timeout" to timeout.toDouble()) }).native) }
+    public actual fun httpsCallable(name: String, timeout: Duration?): HttpsCallableReference =
+        rethrow { HttpsCallableReference(httpsCallable(js, name, timeout?.let { json("timeout" to timeout.toDouble(DurationUnit.MILLISECONDS)) }).native) }
 
     public actual fun useEmulator(host: String, port: Int) {
         connectFunctionsEmulator(js, host, port)

--- a/firebase-perf/src/androidUnitTest/kotlin/dev/gitlive/firebase/perf/performance.kt
+++ b/firebase-perf/src/androidUnitTest/kotlin/dev/gitlive/firebase/perf/performance.kt
@@ -8,8 +8,6 @@ package dev.gitlive.firebase.perf
 
 import org.junit.Ignore
 
-actual val emulatorHost: String = "10.0.2.2"
-
 actual val context: Any = ""
 
 actual typealias IgnoreForAndroidUnitTest = Ignore

--- a/firebase-storage/api/android/firebase-storage.api
+++ b/firebase-storage/api/android/firebase-storage.api
@@ -11,12 +11,12 @@ public final class dev/gitlive/firebase/storage/File {
 public final class dev/gitlive/firebase/storage/FirebaseStorage {
 	public fun <init> (Lcom/google/firebase/storage/FirebaseStorage;)V
 	public final fun getAndroid ()Lcom/google/firebase/storage/FirebaseStorage;
-	public final fun getMaxOperationRetryTimeMillis ()J
-	public final fun getMaxUploadRetryTimeMillis ()J
+	public final fun getMaxOperationRetryTime-UwyO8pc ()J
+	public final fun getMaxUploadRetryTime-UwyO8pc ()J
 	public final fun getReference ()Ldev/gitlive/firebase/storage/StorageReference;
 	public final fun reference (Ljava/lang/String;)Ldev/gitlive/firebase/storage/StorageReference;
-	public final fun setMaxOperationRetryTimeMillis (J)V
-	public final fun setMaxUploadRetryTimeMillis (J)V
+	public final fun setMaxOperationRetryTime-LRDsOJo (J)V
+	public final fun setMaxUploadRetryTime-LRDsOJo (J)V
 	public final fun useEmulator (Ljava/lang/String;I)V
 }
 
@@ -79,6 +79,10 @@ public abstract interface class dev/gitlive/firebase/storage/ProgressFlow : kotl
 }
 
 public final class dev/gitlive/firebase/storage/StorageKt {
+	public static final fun getMaxOperationRetryTimeMillis (Ldev/gitlive/firebase/storage/FirebaseStorage;)J
+	public static final fun getMaxUploadRetryTimeMillis (Ldev/gitlive/firebase/storage/FirebaseStorage;)J
+	public static final fun setMaxOperationRetryTimeMillis (Ldev/gitlive/firebase/storage/FirebaseStorage;J)V
+	public static final fun setMaxUploadRetryTimeMillis (Ldev/gitlive/firebase/storage/FirebaseStorage;J)V
 	public static final fun storageMetadata (Lkotlin/jvm/functions/Function1;)Ldev/gitlive/firebase/storage/FirebaseStorageMetadata;
 }
 

--- a/firebase-storage/api/jvm/firebase-storage.api
+++ b/firebase-storage/api/jvm/firebase-storage.api
@@ -8,12 +8,12 @@ public final class dev/gitlive/firebase/storage/File {
 
 public final class dev/gitlive/firebase/storage/FirebaseStorage {
 	public fun <init> ()V
-	public final fun getMaxOperationRetryTimeMillis ()J
-	public final fun getMaxUploadRetryTimeMillis ()J
+	public final fun getMaxOperationRetryTime-UwyO8pc ()J
+	public final fun getMaxUploadRetryTime-UwyO8pc ()J
 	public final fun getReference ()Ldev/gitlive/firebase/storage/StorageReference;
 	public final fun reference (Ljava/lang/String;)Ldev/gitlive/firebase/storage/StorageReference;
-	public final fun setMaxOperationRetryTimeMillis (J)V
-	public final fun setMaxUploadRetryTimeMillis (J)V
+	public final fun setMaxOperationRetryTime-LRDsOJo (J)V
+	public final fun setMaxUploadRetryTime-LRDsOJo (J)V
 	public final fun useEmulator (Ljava/lang/String;I)V
 }
 
@@ -79,6 +79,10 @@ public abstract interface class dev/gitlive/firebase/storage/ProgressFlow : kotl
 }
 
 public final class dev/gitlive/firebase/storage/StorageKt {
+	public static final fun getMaxOperationRetryTimeMillis (Ldev/gitlive/firebase/storage/FirebaseStorage;)J
+	public static final fun getMaxUploadRetryTimeMillis (Ldev/gitlive/firebase/storage/FirebaseStorage;)J
+	public static final fun setMaxOperationRetryTimeMillis (Ldev/gitlive/firebase/storage/FirebaseStorage;J)V
+	public static final fun setMaxUploadRetryTimeMillis (Ldev/gitlive/firebase/storage/FirebaseStorage;J)V
 	public static final fun storageMetadata (Lkotlin/jvm/functions/Function1;)Ldev/gitlive/firebase/storage/FirebaseStorageMetadata;
 }
 

--- a/firebase-storage/src/androidMain/kotlin/dev/gitlive/firebase/storage/storage.kt
+++ b/firebase-storage/src/androidMain/kotlin/dev/gitlive/firebase/storage/storage.kt
@@ -22,6 +22,8 @@ import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.tasks.await
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 
 public actual val Firebase.storage: FirebaseStorage get() = FirebaseStorage(com.google.firebase.storage.FirebaseStorage.getInstance())
 
@@ -32,15 +34,15 @@ public actual fun Firebase.storage(app: FirebaseApp): FirebaseStorage = Firebase
 public actual fun Firebase.storage(app: FirebaseApp, url: String): FirebaseStorage = FirebaseStorage(com.google.firebase.storage.FirebaseStorage.getInstance(app.android, url))
 
 public actual class FirebaseStorage(public val android: com.google.firebase.storage.FirebaseStorage) {
-    public actual val maxOperationRetryTimeMillis: Long = android.maxOperationRetryTimeMillis
-    public actual val maxUploadRetryTimeMillis: Long = android.maxUploadRetryTimeMillis
+    public actual val maxOperationRetryTime: Duration = android.maxOperationRetryTimeMillis.milliseconds
+    public actual val maxUploadRetryTime: Duration = android.maxUploadRetryTimeMillis.milliseconds
 
-    public actual fun setMaxOperationRetryTimeMillis(maxOperationRetryTimeMillis: Long) {
-        android.maxOperationRetryTimeMillis = maxOperationRetryTimeMillis
+    public actual fun setMaxOperationRetryTime(maxOperationRetryTime: Duration) {
+        android.maxOperationRetryTimeMillis = maxOperationRetryTime.inWholeMilliseconds
     }
 
-    public actual fun setMaxUploadRetryTimeMillis(maxUploadRetryTimeMillis: Long) {
-        android.maxUploadRetryTimeMillis = maxUploadRetryTimeMillis
+    public actual fun setMaxUploadRetryTime(maxUploadRetryTime: Duration) {
+        android.maxUploadRetryTimeMillis = maxUploadRetryTime.inWholeMilliseconds
     }
 
     public actual fun useEmulator(host: String, port: Int) {

--- a/firebase-storage/src/commonMain/kotlin/dev/gitlive/firebase/storage/storage.kt
+++ b/firebase-storage/src/commonMain/kotlin/dev/gitlive/firebase/storage/storage.kt
@@ -4,6 +4,8 @@ import dev.gitlive.firebase.Firebase
 import dev.gitlive.firebase.FirebaseApp
 import dev.gitlive.firebase.FirebaseException
 import kotlinx.coroutines.flow.Flow
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 
 /** Returns the [FirebaseStorage] instance of the default [FirebaseApp]. */
 public expect val Firebase.storage: FirebaseStorage
@@ -32,32 +34,32 @@ public expect class FirebaseStorage {
      * Returns the maximum time to retry operations other than upload and download if a failure
      * occurs.
      *
-     * @return the maximum time in milliseconds. Defaults to 2 minutes (120,000 milliseconds).
+     * @return the maximum time. Defaults to 2 minutes (120,000 milliseconds).
      */
-    public val maxOperationRetryTimeMillis: Long
+    public val maxOperationRetryTime: Duration
 
     /**
      * Returns the maximum time to retry an upload if a failure occurs.
      *
-     * @return the maximum time in milliseconds. Defaults to 10 minutes (600,000 milliseconds).
+     * @return the maximum time. Defaults to 10 minutes (600,000 milliseconds).
      */
-    public val maxUploadRetryTimeMillis: Long
+    public val maxUploadRetryTime: Duration
 
     /**
      * Sets the maximum time to retry operations other than upload and download if a failure occurs.
      *
-     * @param maxTransferRetryMillis the maximum time in milliseconds. Defaults to 2 minutes (120,000
+     * @param maxOperationRetryTime the maximum time. Defaults to 2 minutes (120,000
      *     milliseconds).
      */
-    public fun setMaxOperationRetryTimeMillis(maxOperationRetryTimeMillis: Long)
+    public fun setMaxOperationRetryTime(maxOperationRetryTime: Duration)
 
     /**
      * Sets the maximum time to retry an upload if a failure occurs.
      *
-     * @param maxTransferRetryMillis the maximum time in milliseconds. Defaults to 10 minutes (600,000
+     * @param maxUploadRetryTime the maximum time in milliseconds. Defaults to 10 minutes (600,000
      *     milliseconds).
      */
-    public fun setMaxUploadRetryTimeMillis(maxUploadRetryTimeMillis: Long)
+    public fun setMaxUploadRetryTime(maxUploadRetryTime: Duration)
 
     /**
      * Modifies this FirebaseStorage instance to communicate with the Storage emulator.
@@ -84,6 +86,22 @@ public expect class FirebaseStorage {
      * @return An instance of [StorageReference] at the given child path.
      */
     public fun reference(location: String): StorageReference
+}
+
+@Deprecated("Deprecated to use Kotlin Duration", replaceWith = ReplaceWith("maxOperationRetryTime"))
+public val FirebaseStorage.maxOperationRetryTimeMillis: Long get() = maxOperationRetryTime.inWholeMilliseconds
+
+@Deprecated("Deprecated to use Kotlin Duration", replaceWith = ReplaceWith("maxUploadRetryTime"))
+public val FirebaseStorage.maxUploadRetryTimeMillis: Long get() = maxUploadRetryTime.inWholeMilliseconds
+
+@Deprecated("Deprecated to use Kotlin Duration", replaceWith = ReplaceWith("setMaxOperationRetryTime(maxOperationRetryTimeMillis.milliseconds)"))
+public fun FirebaseStorage.setMaxOperationRetryTimeMillis(maxOperationRetryTimeMillis: Long) {
+    setMaxOperationRetryTime(maxOperationRetryTimeMillis.milliseconds)
+}
+
+@Deprecated("Deprecated to use Kotlin Duration", replaceWith = ReplaceWith("setMaxUploadRetryTime(maxUploadRetryTimeMillis.milliseconds)"))
+public fun FirebaseStorage.setMaxUploadRetryTimeMillis(maxUploadRetryTimeMillis: Long) {
+    setMaxUploadRetryTime(maxUploadRetryTimeMillis.milliseconds)
 }
 
 /**
@@ -158,7 +176,7 @@ public expect class StorageReference {
      * child = foo///bar    path = foo/bar
      * ```
      *
-     * @param pathString The relative path from this reference.
+     * @param path The relative path from this reference.
      * @return the child [StorageReference].
      */
     public fun child(path: String): StorageReference
@@ -175,8 +193,7 @@ public expect class StorageReference {
      * share the file with others, but can be revoked by a developer in the Firebase Console if
      * desired.
      *
-     * @return The [Uri] representing the download URL. You can feed this URL into a [URL]
-     *     and download the object via URL.openStream().
+     * @return The String representing the download URL.
      */
     public suspend fun getDownloadUrl(): String
 
@@ -189,7 +206,6 @@ public expect class StorageReference {
      *
      * [listAll] is only available for projects using Firebase Rules Version 2.
      *
-     * @throws OutOfMemoryError If there are too many items at this location.
      * @return A [ListResult] that returns all items and prefixes under the current StorageReference.
      */
     public suspend fun listAll(): ListResult

--- a/firebase-storage/src/commonTest/kotlin/dev/gitlive/firebase/storage/storage.kt
+++ b/firebase-storage/src/commonTest/kotlin/dev/gitlive/firebase/storage/storage.kt
@@ -15,6 +15,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.time.Duration.Companion.seconds
 
 expect val emulatorHost: String
 expect val context: Any
@@ -41,8 +42,8 @@ class FirebaseStorageTest {
 
         storage = Firebase.storage(app).apply {
             useEmulator(emulatorHost, 9199)
-            setMaxOperationRetryTimeMillis(10000)
-            setMaxUploadRetryTimeMillis(10000)
+            setMaxOperationRetryTime(10.seconds)
+            setMaxUploadRetryTime(10.seconds)
         }
     }
 

--- a/firebase-storage/src/iosMain/kotlin/dev/gitlive/firebase/storage/storage.kt
+++ b/firebase-storage/src/iosMain/kotlin/dev/gitlive/firebase/storage/storage.kt
@@ -26,6 +26,9 @@ import kotlinx.coroutines.flow.emitAll
 import platform.Foundation.NSData
 import platform.Foundation.NSError
 import platform.Foundation.NSURL
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.DurationUnit
 
 public actual val Firebase.storage: FirebaseStorage get() =
     FirebaseStorage(FIRStorage.storage())
@@ -43,15 +46,15 @@ public actual fun Firebase.storage(app: FirebaseApp, url: String): FirebaseStora
 )
 
 public actual class FirebaseStorage(public val ios: FIRStorage) {
-    public actual val maxOperationRetryTimeMillis: Long = ios.maxOperationRetryTime().toLong()
-    public actual val maxUploadRetryTimeMillis: Long = ios.maxUploadRetryTime().toLong()
+    public actual val maxOperationRetryTime: Duration = ios.maxOperationRetryTime().seconds
+    public actual val maxUploadRetryTime: Duration = ios.maxUploadRetryTime().seconds
 
-    public actual fun setMaxOperationRetryTimeMillis(maxOperationRetryTimeMillis: Long) {
-        ios.setMaxOperationRetryTime(maxOperationRetryTimeMillis.toDouble())
+    public actual fun setMaxOperationRetryTime(maxOperationRetryTime: Duration) {
+        ios.setMaxOperationRetryTime(maxOperationRetryTime.toDouble(DurationUnit.SECONDS))
     }
 
-    public actual fun setMaxUploadRetryTimeMillis(maxUploadRetryTimeMillis: Long) {
-        ios.setMaxUploadRetryTime(maxUploadRetryTimeMillis.toDouble())
+    public actual fun setMaxUploadRetryTime(maxUploadRetryTime: Duration) {
+        ios.setMaxUploadRetryTime(maxUploadRetryTime.toDouble(DurationUnit.SECONDS))
     }
 
     public actual fun useEmulator(host: String, port: Int) {

--- a/firebase-storage/src/jsMain/kotlin/dev/gitlive/firebase/storage/storage.kt
+++ b/firebase-storage/src/jsMain/kotlin/dev/gitlive/firebase/storage/storage.kt
@@ -16,6 +16,9 @@ import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.emitAll
 import kotlin.js.Json
 import kotlin.js.json
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.DurationUnit
 
 public actual val Firebase.storage: FirebaseStorage
     get() = FirebaseStorage(getStorage())
@@ -27,15 +30,15 @@ public actual fun Firebase.storage(app: FirebaseApp): FirebaseStorage = Firebase
 public actual fun Firebase.storage(app: FirebaseApp, url: String): FirebaseStorage = FirebaseStorage(getStorage(app.js, url))
 
 public actual class FirebaseStorage(public val js: dev.gitlive.firebase.storage.externals.FirebaseStorage) {
-    public actual val maxOperationRetryTimeMillis: Long = js.maxOperationRetryTime.toLong()
-    public actual val maxUploadRetryTimeMillis: Long = js.maxUploadRetryTime.toLong()
+    public actual val maxOperationRetryTime: Duration = js.maxOperationRetryTime.milliseconds
+    public actual val maxUploadRetryTime: Duration = js.maxUploadRetryTime.milliseconds
 
-    public actual fun setMaxOperationRetryTimeMillis(maxOperationRetryTimeMillis: Long) {
-        js.maxOperationRetryTime = maxOperationRetryTimeMillis.toDouble()
+    public actual fun setMaxOperationRetryTime(maxOperationRetryTime: Duration) {
+        js.maxOperationRetryTime = maxOperationRetryTime.toDouble(DurationUnit.MILLISECONDS)
     }
 
-    public actual fun setMaxUploadRetryTimeMillis(maxUploadRetryTimeMillis: Long) {
-        js.maxUploadRetryTime = maxUploadRetryTimeMillis.toDouble()
+    public actual fun setMaxUploadRetryTime(maxUploadRetryTime: Duration) {
+        js.maxUploadRetryTime = maxUploadRetryTime.toDouble(DurationUnit.MILLISECONDS)
     }
 
     public actual fun useEmulator(host: String, port: Int) {

--- a/firebase-storage/src/jvmMain/kotlin/dev/gitlive/firebase/storage/storage.jvm.kt
+++ b/firebase-storage/src/jvmMain/kotlin/dev/gitlive/firebase/storage/storage.jvm.kt
@@ -3,6 +3,7 @@ package dev.gitlive.firebase.storage
 import dev.gitlive.firebase.Firebase
 import dev.gitlive.firebase.FirebaseApp
 import dev.gitlive.firebase.FirebaseException
+import kotlin.time.Duration
 
 /** Returns the [FirebaseStorage] instance of the default [FirebaseApp]. */
 public actual val Firebase.storage: FirebaseStorage
@@ -16,15 +17,15 @@ public actual fun Firebase.storage(app: FirebaseApp): FirebaseStorage = TODO("No
 public actual fun Firebase.storage(app: FirebaseApp, url: String): FirebaseStorage = TODO("Not yet implemented")
 
 public actual class FirebaseStorage {
-    public actual val maxOperationRetryTimeMillis: Long
+    public actual val maxOperationRetryTime: Duration
         get() = TODO("Not yet implemented")
-    public actual val maxUploadRetryTimeMillis: Long
+    public actual val maxUploadRetryTime: Duration
         get() = TODO("Not yet implemented")
 
-    public actual fun setMaxOperationRetryTimeMillis(maxOperationRetryTimeMillis: Long) {
+    public actual fun setMaxOperationRetryTime(maxOperationRetryTime: Duration) {
     }
 
-    public actual fun setMaxUploadRetryTimeMillis(maxUploadRetryTimeMillis: Long) {
+    public actual fun setMaxUploadRetryTime(maxUploadRetryTime: Duration) {
     }
 
     public actual fun useEmulator(host: String, port: Int) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,12 +12,14 @@ kotlin = "2.0.0"
 kotlinx-coroutines = "1.9.0-RC"
 kotlinx-serialization = "1.7.0"
 kotlinx-binarycompatibilityvalidator = "0.15.0-Beta.2"
+kotlinx-datetime = "0.6.0"
 kotlinter = "4.4.0"
 settings-api = "2.0"
 settings-language = "2.0"
 firebase-cocoapods = "10.28.0"
 test-logger-plugin = "3.2.0"
 dokka = "1.9.20"
+desugar-libs = "2.0.3"
 
 [libraries]
 android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }
@@ -45,7 +47,9 @@ kotlinx-coroutines-play-services = { module = "org.jetbrains.kotlinx:kotlinx-cor
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-swing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
 kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinx-serialization" }
+kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 dokka-base = { module = "org.jetbrains.dokka:dokka-base", version.ref = "dokka" }
+android-desugarjdk = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugar-libs" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Fixes a bit of a pet peeve to me: When dealing with Intervals and Timestamps, on Kotlin we should be using Kotlin Duration and Kotlin DateTime Instant instead of using Longs.

My reasoning behind this:
- Duration gives annotation to the meaning of a long. No longer do you need to check documentation what the long means (or check if we're using seconds or milliseconds)
- The NSTimeInterval is in seconds while Android/JS communicate in milliseconds. This already lead to several bugs that I've solved in this PR. Using duration makes making mistakes less likely
- If you want to set some timeout to say 3 hours, you no longer need to do calculations like `3 * 60 * 60 * 1000` as you can just pass `3.hours`. This leads to better usage of the library