### PR TITLE
Make setUserId accept nullable user id to clear user id.

### DIFF
--- a/firebase-analytics/src/androidMain/kotlin/dev/gitlive/firebase/analytics/analytics.kt
+++ b/firebase-analytics/src/androidMain/kotlin/dev/gitlive/firebase/analytics/analytics.kt
@@ -23,7 +23,7 @@ public actual class FirebaseAnalytics(public val android: com.google.firebase.an
     public actual fun setUserProperty(name: String, value: String) {
         android.setUserProperty(name, value)
     }
-    public actual fun setUserId(id: String) {
+    public actual fun setUserId(id: String?) {
         android.setUserId(id)
     }
     public actual fun resetAnalyticsData() {

--- a/firebase-analytics/src/commonMain/kotlin/dev/gitlive/firebase/analytics/analytics.kt
+++ b/firebase-analytics/src/commonMain/kotlin/dev/gitlive/firebase/analytics/analytics.kt
@@ -13,7 +13,7 @@ public expect fun Firebase.analytics(app: FirebaseApp): FirebaseAnalytics
 public expect class FirebaseAnalytics {
     public fun logEvent(name: String, parameters: Map<String, Any>? = null)
     public fun setUserProperty(name: String, value: String)
-    public fun setUserId(id: String)
+    public fun setUserId(id: String?)
     public fun setAnalyticsCollectionEnabled(enabled: Boolean)
     public fun setSessionTimeoutInterval(sessionTimeoutInterval: Duration)
     public suspend fun getSessionId(): Long?

--- a/firebase-analytics/src/iosMain/kotlin/dev/gitlive/firebase/analytics/analytics.kt
+++ b/firebase-analytics/src/iosMain/kotlin/dev/gitlive/firebase/analytics/analytics.kt
@@ -23,7 +23,7 @@ public actual class FirebaseAnalytics(public val ios: FIRAnalytics.Companion) {
     public actual fun setUserProperty(name: String, value: String) {
         ios.setUserPropertyString(value, name)
     }
-    public actual fun setUserId(id: String) {
+    public actual fun setUserId(id: String?) {
         ios.setUserID(id)
     }
     public actual fun resetAnalyticsData() {

--- a/firebase-analytics/src/jsMain/kotlin/dev/gitlive/firebase/analytics/analytics.kt
+++ b/firebase-analytics/src/jsMain/kotlin/dev/gitlive/firebase/analytics/analytics.kt
@@ -25,7 +25,7 @@ public actual class FirebaseAnalytics(public val js: dev.gitlive.firebase.analyt
         dev.gitlive.firebase.analytics.externals.setUserProperty(js, name, value)
     }
 
-    public actual fun setUserId(id: String) {
+    public actual fun setUserId(id: String?) {
         dev.gitlive.firebase.analytics.externals.setUserId(js, id)
     }
 

--- a/firebase-analytics/src/jsMain/kotlin/dev/gitlive/firebase/analytics/externals/analytics.kt
+++ b/firebase-analytics/src/jsMain/kotlin/dev/gitlive/firebase/analytics/externals/analytics.kt
@@ -11,7 +11,7 @@ public external fun getAnalytics(app: FirebaseApp? = definedExternally): Firebas
 
 public external fun logEvent(app: FirebaseAnalytics, name: String, parameters: Map<String, Any>?)
 public external fun setUserProperty(app: FirebaseAnalytics, name: String, value: String)
-public external fun setUserId(app: FirebaseAnalytics, id: String)
+public external fun setUserId(app: FirebaseAnalytics, id: String?)
 public external fun resetAnalyticsData(app: FirebaseAnalytics)
 public external fun setDefaultEventParameters(app: FirebaseAnalytics, parameters: Map<String, String>)
 public external fun setAnalyticsCollectionEnabled(app: FirebaseAnalytics, enabled: Boolean)

--- a/firebase-analytics/src/jvmMain/kotlin/dev/gitlive/firebase/analytics/analytics.jvm.kt
+++ b/firebase-analytics/src/jvmMain/kotlin/dev/gitlive/firebase/analytics/analytics.jvm.kt
@@ -14,7 +14,7 @@ public actual fun Firebase.analytics(app: FirebaseApp): FirebaseAnalytics {
 
 public actual class FirebaseAnalytics {
     public actual fun setUserProperty(name: String, value: String) {}
-    public actual fun setUserId(id: String) {}
+    public actual fun setUserId(id: String?) {}
     public actual fun resetAnalyticsData() {}
     public actual fun setAnalyticsCollectionEnabled(enabled: Boolean) {}
     public actual fun setSessionTimeoutInterval(sessionTimeoutInterval: Duration) {}


### PR DESCRIPTION
`setUserId` needs to take a nullable String (currently non-nullable), so that user id can be cleared. Useful for instance at logout.