### PR TITLE
Added support for deleting FCM token

### DIFF
--- a/firebase-messaging/api/android/firebase-messaging.api
+++ b/firebase-messaging/api/android/firebase-messaging.api
@@ -1,5 +1,6 @@
 public final class dev/gitlive/firebase/messaging/FirebaseMessaging {
 	public fun <init> (Lcom/google/firebase/messaging/FirebaseMessaging;)V
+	public final fun deleteToken (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getAndroid ()Lcom/google/firebase/messaging/FirebaseMessaging;
 	public final fun getToken (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun subscribeToTopic (Ljava/lang/String;)V

--- a/firebase-messaging/api/jvm/firebase-messaging.api
+++ b/firebase-messaging/api/jvm/firebase-messaging.api
@@ -1,5 +1,6 @@
 public final class dev/gitlive/firebase/messaging/FirebaseMessaging {
 	public fun <init> ()V
+	public final fun deleteToken (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getToken (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun subscribeToTopic (Ljava/lang/String;)V
 	public final fun unsubscribeFromTopic (Ljava/lang/String;)V

--- a/firebase-messaging/src/androidMain/kotlin/dev/gitlive/firebase/messaging/messaging.kt
+++ b/firebase-messaging/src/androidMain/kotlin/dev/gitlive/firebase/messaging/messaging.kt
@@ -18,4 +18,8 @@ public actual class FirebaseMessaging(public val android: com.google.firebase.me
     }
 
     public actual suspend fun getToken(): String = android.token.await()
+
+    public actual suspend fun deleteToken() {
+        android.deleteToken().await()
+    }
 }

--- a/firebase-messaging/src/commonMain/kotlin/dev/gitlive/firebase/messaging/messaging.kt
+++ b/firebase-messaging/src/commonMain/kotlin/dev/gitlive/firebase/messaging/messaging.kt
@@ -28,4 +28,9 @@ public expect class FirebaseMessaging {
      * @return [String] FCM token
      */
     public suspend fun getToken(): String
+
+    /**
+     * Delete FCM token for client
+     */
+    public suspend fun deleteToken()
 }

--- a/firebase-messaging/src/iosMain/kotlin/dev/gitlive/firebase/messaging/messaging.kt
+++ b/firebase-messaging/src/iosMain/kotlin/dev/gitlive/firebase/messaging/messaging.kt
@@ -18,6 +18,10 @@ public actual class FirebaseMessaging(public val ios: FIRMessaging) {
     }
 
     public actual suspend fun getToken(): String = awaitResult { ios.tokenWithCompletion(it) }
+
+    public actual suspend fun deleteToken() {
+        await { ios.deleteTokenWithCompletion(it) }
+    }
 }
 
 public suspend inline fun <T> T.await(function: T.(callback: (NSError?) -> Unit) -> Unit) {

--- a/firebase-messaging/src/jsMain/kotlin/dev/gitlive/firebase/messaging/externals/messaging.kt
+++ b/firebase-messaging/src/jsMain/kotlin/dev/gitlive/firebase/messaging/externals/messaging.kt
@@ -9,4 +9,6 @@ public external fun getMessaging(
 
 public external fun getToken(messaging: Messaging = definedExternally, options: dynamic = definedExternally): Promise<String>
 
+public external fun deleteToken(messaging: Messaging = definedExternally): Promise<Boolean>
+
 public external interface Messaging

--- a/firebase-messaging/src/jsMain/kotlin/dev/gitlive/firebase/messaging/messaging.kt
+++ b/firebase-messaging/src/jsMain/kotlin/dev/gitlive/firebase/messaging/messaging.kt
@@ -22,4 +22,8 @@ public actual class FirebaseMessaging(public val js: Messaging) {
     }
 
     public actual suspend fun getToken(): String = dev.gitlive.firebase.messaging.externals.getToken(js).await()
+
+    public actual suspend fun deleteToken() {
+        dev.gitlive.firebase.messaging.externals.deleteToken(js).await()
+    }
 }

--- a/firebase-messaging/src/jvmMain/kotlin/dev/gitlive/firebase/messaging/messaging.kt
+++ b/firebase-messaging/src/jvmMain/kotlin/dev/gitlive/firebase/messaging/messaging.kt
@@ -19,4 +19,8 @@ public actual class FirebaseMessaging {
     public actual suspend fun getToken(): String {
         TODO("Not yet implemented")
     }
+
+    public actual suspend fun deleteToken() {
+        TODO("Not yet implemented")
+    }
 }


### PR DESCRIPTION
Added support for the android `deleteToken()` and ios `deleteTokenWithCompletion()` functions for FCM