### PR TITLE
Added get reference from url

### DIFF
--- a/firebase-storage/api/android/firebase-storage.api
+++ b/firebase-storage/api/android/firebase-storage.api
@@ -13,6 +13,7 @@ public final class dev/gitlive/firebase/storage/FirebaseStorage {
 	public final fun getMaxOperationRetryTime-UwyO8pc ()J
 	public final fun getMaxUploadRetryTime-UwyO8pc ()J
 	public final fun getReference ()Ldev/gitlive/firebase/storage/StorageReference;
+	public final fun getReferenceFromUrl (Ljava/lang/String;)Ldev/gitlive/firebase/storage/StorageReference;
 	public final fun reference (Ljava/lang/String;)Ldev/gitlive/firebase/storage/StorageReference;
 	public final fun setMaxOperationRetryTime-LRDsOJo (J)V
 	public final fun setMaxUploadRetryTime-LRDsOJo (J)V

--- a/firebase-storage/api/jvm/firebase-storage.api
+++ b/firebase-storage/api/jvm/firebase-storage.api
@@ -11,6 +11,7 @@ public final class dev/gitlive/firebase/storage/FirebaseStorage {
 	public final fun getMaxOperationRetryTime-UwyO8pc ()J
 	public final fun getMaxUploadRetryTime-UwyO8pc ()J
 	public final fun getReference ()Ldev/gitlive/firebase/storage/StorageReference;
+	public final fun getReferenceFromUrl (Ljava/lang/String;)Ldev/gitlive/firebase/storage/StorageReference;
 	public final fun reference (Ljava/lang/String;)Ldev/gitlive/firebase/storage/StorageReference;
 	public final fun setMaxOperationRetryTime-LRDsOJo (J)V
 	public final fun setMaxUploadRetryTime-LRDsOJo (J)V

--- a/firebase-storage/src/androidMain/kotlin/dev/gitlive/firebase/storage/storage.kt
+++ b/firebase-storage/src/androidMain/kotlin/dev/gitlive/firebase/storage/storage.kt
@@ -55,6 +55,8 @@ public actual class FirebaseStorage(internal val android: com.google.firebase.st
     public actual val reference: StorageReference get() = StorageReference(android.reference)
 
     public actual fun reference(location: String): StorageReference = StorageReference(android.getReference(location))
+
+    public actual fun getReferenceFromUrl(fullUrl: String): StorageReference = StorageReference(android.getReferenceFromUrl(fullUrl))
 }
 
 public val StorageReference.android: com.google.firebase.storage.StorageReference get() = android

--- a/firebase-storage/src/commonMain/kotlin/dev/gitlive/firebase/storage/storage.kt
+++ b/firebase-storage/src/commonMain/kotlin/dev/gitlive/firebase/storage/storage.kt
@@ -86,6 +86,16 @@ public expect class FirebaseStorage {
      * @return An instance of [StorageReference] at the given child path.
      */
     public fun reference(location: String): StorageReference
+
+    /**
+     * Creates a [StorageReference] given a gs:// or https:// URL pointing to a Firebase Storage location.
+     *
+     * @param fullUrl A gs:// or http[s]:// URL used to initialize the reference. For example, you can pass
+     *     in a download URL retrieved from getDownloadUrl or the uri retrieved from toString An error is
+     *     thrown if fullUrl is not associated with the FirebaseApp used to initialize this FirebaseStorage.
+     * @return An instance of [StorageReference] at the given url.
+     */
+    public fun getReferenceFromUrl(fullUrl: String): StorageReference
 }
 
 @Deprecated("Deprecated to use Kotlin Duration", replaceWith = ReplaceWith("maxOperationRetryTime"))

--- a/firebase-storage/src/iosMain/kotlin/dev/gitlive/firebase/storage/storage.kt
+++ b/firebase-storage/src/iosMain/kotlin/dev/gitlive/firebase/storage/storage.kt
@@ -67,6 +67,8 @@ public actual class FirebaseStorage(internal val ios: FIRStorage) {
     public actual val reference: StorageReference get() = StorageReference(ios.reference())
 
     public actual fun reference(location: String): StorageReference = StorageReference(ios.referenceWithPath(location))
+
+    public actual fun getReferenceFromUrl(fullUrl: String): StorageReference = StorageReference(ios.referenceForURL(fullUrl))
 }
 
 public val StorageReference.ios: FIRStorageReference get() = ios

--- a/firebase-storage/src/jsMain/kotlin/dev/gitlive/firebase/storage/storage.kt
+++ b/firebase-storage/src/jsMain/kotlin/dev/gitlive/firebase/storage/storage.kt
@@ -51,6 +51,8 @@ public actual class FirebaseStorage(internal val js: dev.gitlive.firebase.storag
     public actual val reference: StorageReference get() = StorageReference(ref(js))
 
     public actual fun reference(location: String): StorageReference = rethrow { StorageReference(ref(js, location)) }
+
+    public actual fun getReferenceFromUrl(fullUrl: String): StorageReference = rethrow { StorageReference(ref(js, fullUrl)) }
 }
 
 public val StorageReference.js get() = js

--- a/firebase-storage/src/jvmMain/kotlin/dev/gitlive/firebase/storage/storage.jvm.kt
+++ b/firebase-storage/src/jvmMain/kotlin/dev/gitlive/firebase/storage/storage.jvm.kt
@@ -37,6 +37,10 @@ public actual class FirebaseStorage {
     public actual fun reference(location: String): StorageReference {
         TODO("Not yet implemented")
     }
+
+    public actual fun getReferenceFromUrl(fullUrl: String): StorageReference {
+        TODO("Not yet implemented")
+    }
 }
 
 public actual class StorageReference {


### PR DESCRIPTION
Added the missing method: https://firebase.google.com/docs/reference/kotlin/com/google/firebase/storage/FirebaseStorage#getReferenceFromUrl(java.lang.String)