### PR TITLE
FIX target OAuth provider not accessable

### DIFF
--- a/firebase-auth/src/androidMain/kotlin/dev/gitlive/firebase/auth/credentials.kt
+++ b/firebase-auth/src/androidMain/kotlin/dev/gitlive/firebase/auth/credentials.kt
@@ -52,7 +52,7 @@ public actual object GoogleAuthProvider {
     }
 }
 
-public actual class OAuthProvider(val android: AndroidOAuthProvider) {
+public actual class OAuthProvider(public val android: AndroidOAuthProvider) {
 
     public actual constructor(
         provider: String,

--- a/firebase-auth/src/androidMain/kotlin/dev/gitlive/firebase/auth/credentials.kt
+++ b/firebase-auth/src/androidMain/kotlin/dev/gitlive/firebase/auth/credentials.kt
@@ -52,9 +52,7 @@ public actual object GoogleAuthProvider {
     }
 }
 
-public val OAuthProvider.android: AndroidOAuthProvider get() = android
-
-public actual class OAuthProvider(internal val android: AndroidOAuthProvider) {
+public actual class OAuthProvider(val android: AndroidOAuthProvider) {
 
     public actual constructor(
         provider: String,

--- a/firebase-auth/src/iosMain/kotlin/dev/gitlive/firebase/auth/credentials.kt
+++ b/firebase-auth/src/iosMain/kotlin/dev/gitlive/firebase/auth/credentials.kt
@@ -44,9 +44,7 @@ public actual object GoogleAuthProvider {
     }
 }
 
-public val OAuthProvider.ios: FIROAuthProvider get() = ios
-
-public actual class OAuthProvider(internal val ios: FIROAuthProvider) {
+public actual class OAuthProvider(val ios: FIROAuthProvider) {
 
     public actual constructor(
         provider: String,
@@ -72,9 +70,7 @@ public actual class OAuthProvider(internal val ios: FIROAuthProvider) {
     }
 }
 
-public val PhoneAuthProvider.ios: FIRPhoneAuthProvider get() = ios
-
-public actual class PhoneAuthProvider(internal val ios: FIRPhoneAuthProvider) {
+public actual class PhoneAuthProvider(val ios: FIRPhoneAuthProvider) {
 
     public actual constructor(auth: FirebaseAuth) : this(FIRPhoneAuthProvider.providerWithAuth(auth.ios))
 

--- a/firebase-auth/src/iosMain/kotlin/dev/gitlive/firebase/auth/credentials.kt
+++ b/firebase-auth/src/iosMain/kotlin/dev/gitlive/firebase/auth/credentials.kt
@@ -44,7 +44,7 @@ public actual object GoogleAuthProvider {
     }
 }
 
-public actual class OAuthProvider(val ios: FIROAuthProvider) {
+public actual class OAuthProvider(public val ios: FIROAuthProvider) {
 
     public actual constructor(
         provider: String,
@@ -70,7 +70,7 @@ public actual class OAuthProvider(val ios: FIROAuthProvider) {
     }
 }
 
-public actual class PhoneAuthProvider(val ios: FIRPhoneAuthProvider) {
+public actual class PhoneAuthProvider(public val ios: FIRPhoneAuthProvider) {
 
     public actual constructor(auth: FirebaseAuth) : this(FIRPhoneAuthProvider.providerWithAuth(auth.ios))
 

--- a/firebase-auth/src/jsMain/kotlin/dev/gitlive/firebase/auth/credentials.kt
+++ b/firebase-auth/src/jsMain/kotlin/dev/gitlive/firebase/auth/credentials.kt
@@ -51,9 +51,7 @@ public actual object GoogleAuthProvider {
     }
 }
 
-public val OAuthProvider.js: JsOAuthProvider get() = js
-
-public actual class OAuthProvider(internal val js: JsOAuthProvider) {
+public actual class OAuthProvider(val js: JsOAuthProvider) {
 
     public actual constructor(
         provider: String,
@@ -82,9 +80,7 @@ public actual class OAuthProvider(internal val js: JsOAuthProvider) {
     }
 }
 
-public val PhoneAuthProvider.js: JsPhoneAuthProvider get() = js
-
-public actual class PhoneAuthProvider(internal val js: JsPhoneAuthProvider) {
+public actual class PhoneAuthProvider(val js: JsPhoneAuthProvider) {
 
     public actual constructor(auth: FirebaseAuth) : this(JsPhoneAuthProvider(auth.js))
 

--- a/firebase-auth/src/jsMain/kotlin/dev/gitlive/firebase/auth/credentials.kt
+++ b/firebase-auth/src/jsMain/kotlin/dev/gitlive/firebase/auth/credentials.kt
@@ -51,7 +51,7 @@ public actual object GoogleAuthProvider {
     }
 }
 
-public actual class OAuthProvider(val js: JsOAuthProvider) {
+public actual class OAuthProvider(public val js: JsOAuthProvider) {
 
     public actual constructor(
         provider: String,
@@ -80,7 +80,7 @@ public actual class OAuthProvider(val js: JsOAuthProvider) {
     }
 }
 
-public actual class PhoneAuthProvider(val js: JsPhoneAuthProvider) {
+public actual class PhoneAuthProvider(public val js: JsPhoneAuthProvider) {
 
     public actual constructor(auth: FirebaseAuth) : this(JsPhoneAuthProvider(auth.js))
 

--- a/firebase-auth/src/jvmMain/kotlin/dev/gitlive/firebase/auth/credentials.kt
+++ b/firebase-auth/src/jvmMain/kotlin/dev/gitlive/firebase/auth/credentials.kt
@@ -52,9 +52,7 @@ public actual object GoogleAuthProvider {
     }
 }
 
-public val OAuthProvider.android: com.google.firebase.auth.OAuthProvider get() = android
-
-public actual class OAuthProvider(internal val android: com.google.firebase.auth.OAuthProvider) {
+public actual class OAuthProvider(val android: com.google.firebase.auth.OAuthProvider) {
 
     public actual constructor(
         provider: String,
@@ -80,9 +78,7 @@ public actual class OAuthProvider(internal val android: com.google.firebase.auth
     }
 }
 
-public val PhoneAuthProvider.android: com.google.firebase.auth.PhoneAuthProvider get() = android
-
-public actual class PhoneAuthProvider(internal val android: com.google.firebase.auth.PhoneAuthProvider) {
+public actual class PhoneAuthProvider(val android: com.google.firebase.auth.PhoneAuthProvider) {
 
     public actual constructor(auth: FirebaseAuth) : this(com.google.firebase.auth.PhoneAuthProvider.getInstance(auth.android))
 

--- a/firebase-auth/src/jvmMain/kotlin/dev/gitlive/firebase/auth/credentials.kt
+++ b/firebase-auth/src/jvmMain/kotlin/dev/gitlive/firebase/auth/credentials.kt
@@ -52,7 +52,7 @@ public actual object GoogleAuthProvider {
     }
 }
 
-public actual class OAuthProvider(val android: com.google.firebase.auth.OAuthProvider) {
+public actual class OAuthProvider(public val android: com.google.firebase.auth.OAuthProvider) {
 
     public actual constructor(
         provider: String,
@@ -78,7 +78,7 @@ public actual class OAuthProvider(val android: com.google.firebase.auth.OAuthPro
     }
 }
 
-public actual class PhoneAuthProvider(val android: com.google.firebase.auth.PhoneAuthProvider) {
+public actual class PhoneAuthProvider(public val android: com.google.firebase.auth.PhoneAuthProvider) {
 
     public actual constructor(auth: FirebaseAuth) : this(com.google.firebase.auth.PhoneAuthProvider.getInstance(auth.android))
 


### PR DESCRIPTION
It's not possible to access the target specific OAuth provider, as the field was marked internal and a extension field with the same name was present, resulting in an error like this: `Cannot access 'val android: OAuthProvider': it is internal in 'dev/gitlive/firebase/auth/OAuthProvider'.`