### PR TITLE
Fix iOS setCustomKey wrong param order

### DIFF
--- a/firebase-crashlytics/src/iosMain/kotlin/dev/gitlive/firebase/crashlytics/crashlytics.kt
+++ b/firebase-crashlytics/src/iosMain/kotlin/dev/gitlive/firebase/crashlytics/crashlytics.kt
@@ -37,22 +37,22 @@ public actual class FirebaseCrashlytics internal constructor(internal val ios: F
     }
     public actual fun didCrashOnPreviousExecution(): Boolean = ios.didCrashDuringPreviousExecution()
     public actual fun setCustomKey(key: String, value: String) {
-        ios.setCustomValue(key, value)
+        ios.setCustomValue(value, key)
     }
     public actual fun setCustomKey(key: String, value: Boolean) {
-        ios.setCustomValue(key, value.toString())
+        ios.setCustomValue(value.toString(), key)
     }
     public actual fun setCustomKey(key: String, value: Double) {
-        ios.setCustomValue(key, value.toString())
+        ios.setCustomValue(value.toString(), key)
     }
     public actual fun setCustomKey(key: String, value: Float) {
-        ios.setCustomValue(key, value.toString())
+        ios.setCustomValue(value.toString(), key)
     }
     public actual fun setCustomKey(key: String, value: Int) {
-        ios.setCustomValue(key, value.toString())
+        ios.setCustomValue(value.toString(), key)
     }
     public actual fun setCustomKey(key: String, value: Long) {
-        ios.setCustomValue(key, value.toString())
+        ios.setCustomValue(value.toString(), key)
     }
 
     @Suppress("UNCHECKED_CAST")


### PR DESCRIPTION
Fixes https://github.com/GitLiveApp/firebase-kotlin-sdk/issues/520

According to the docs: https://firebase.google.com/docs/crashlytics/customize-crash-reports?platform=ios#add-keys
the order of setCustomValue parameters is: value, key

setCustomKeysAndValues still expects to order of the map elements to be key, value - so no changes there.