### PR TITLE
Moved Lint and API checks to pull_request_target.yml

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,26 +8,10 @@ on:
     branches: [ master ]
 
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ci-pull-request-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  lintAndApiChecks:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up JDK
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'zulu'
-          java-version: '17'
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: latest-stable
-      - name: Lint Kotlin
-        run: ./gradlew lintKotlin
-      - name: Api File Update
-        run: ./gradlew apiCheck
   jobMatrixSetup:
     needs: lintAndApiChecks
     runs-on: macos-latest

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,7 +13,6 @@ concurrency:
 
 jobs:
   jobMatrixSetup:
-    needs: lintAndApiChecks
     runs-on: macos-latest
     outputs:
       emulator_jobs_matrix: ${{ steps.dataStep.outputs.emulator_jobs_matrix }}

--- a/.github/workflows/pull_request_target.yml
+++ b/.github/workflows/pull_request_target.yml
@@ -1,11 +1,11 @@
-name: Pull Request Target
+name: Lint and API Checks
 
 on:
   pull_request_target:
     branches: [ master ]
 
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ci-lint-api-check-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -20,6 +20,16 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '17'
+          cache: gradle
+      - name: Cocoapods cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cocoapods
+            ~/Library/Caches/CocoaPods
+            */build/cocoapods
+            */build/classes
+          key: cocoapods-cache-v2
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable


### PR DESCRIPTION
The `lintAndApiChecks` job was moved from `pull_request.yml` to `pull_request_target.yml`. This change consolidates linting and API checks into a single workflow. The concurrency group names were updated to reflect this change. Added Gradle and Cocoapods caching to the `lintAndApiChecks` job.