### PR TITLE
feat(crashlytics): add recordException overload with custom keys

### DIFF
--- a/firebase-crashlytics/src/androidMain/kotlin/dev/gitlive/firebase/crashlytics/crashlytics.kt
+++ b/firebase-crashlytics/src/androidMain/kotlin/dev/gitlive/firebase/crashlytics/crashlytics.kt
@@ -1,6 +1,7 @@
 package dev.gitlive.firebase.crashlytics
 
 import com.google.firebase.FirebaseException
+import com.google.firebase.crashlytics.CustomKeysAndValues
 import com.google.firebase.crashlytics.CustomKeysAndValues.Builder
 import dev.gitlive.firebase.Firebase
 import dev.gitlive.firebase.FirebaseApp
@@ -17,6 +18,9 @@ public actual class FirebaseCrashlytics internal constructor(internal val androi
 
     public actual fun recordException(exception: Throwable) {
         android.recordException(exception)
+    }
+    public actual fun recordException(exception: Throwable, customKeys: Map<String, Any>) {
+        android.recordException(exception, customKeys.toCustomKeysAndValues())
     }
     public actual fun log(message: String) {
         android.log(message)
@@ -68,6 +72,23 @@ public actual class FirebaseCrashlytics internal constructor(internal val androi
             }.build(),
         )
     }
+}
+
+
+private fun Map<String, Any>.toCustomKeysAndValues(): CustomKeysAndValues {
+    val b = Builder()
+    for ((k, v) in this) {
+        when (v) {
+            is String -> b.putString(k, v)
+            is Boolean -> b.putBoolean(k, v)
+            is Int -> b.putInt(k, v)
+            is Long -> b.putLong(k, v)
+            is Float -> b.putFloat(k, v)
+            is Double -> b.putDouble(k, v)
+            else -> b.putString(k, v.toString()) // 지원 안 하면 문자열로
+        }
+    }
+    return b.build()
 }
 
 public actual open class FirebaseCrashlyticsException(message: String) : FirebaseException(message)

--- a/firebase-crashlytics/src/appleMain/kotlin/dev/gitlive/firebase/crashlytics/crashlytics.kt
+++ b/firebase-crashlytics/src/appleMain/kotlin/dev/gitlive/firebase/crashlytics/crashlytics.kt
@@ -19,6 +19,10 @@ public actual class FirebaseCrashlytics internal constructor(internal val ios: F
     public actual fun recordException(exception: Throwable) {
         ios.recordError(exception.asNSError())
     }
+    @Suppress("UNCHECKED_CAST")
+    public actual fun recordException(exception: Throwable, customKeys: Map<String, Any>) {
+        ios.recordError(exception.asNSError(), customKeys as Map<Any?,*>)
+    }
     public actual fun log(message: String) {
         ios.log(message)
     }
@@ -58,6 +62,7 @@ public actual class FirebaseCrashlytics internal constructor(internal val ios: F
     public actual fun setCustomKeys(customKeys: Map<String, Any>) {
         ios.setCustomKeysAndValues(customKeys as Map<Any?, *>)
     }
+
 }
 
 public actual open class FirebaseCrashlyticsException internal constructor(message: String) : FirebaseException(message)

--- a/firebase-crashlytics/src/commonMain/kotlin/dev/gitlive/firebase/crashlytics/crashlytics.kt
+++ b/firebase-crashlytics/src/commonMain/kotlin/dev/gitlive/firebase/crashlytics/crashlytics.kt
@@ -28,6 +28,29 @@ public expect class FirebaseCrashlytics {
     public fun recordException(exception: Throwable)
 
     /**
+     * Records a non-fatal event with additional custom keys.
+     *
+     * This is a convenience overload to attach diagnostic metadata together with a non-fatal report.
+     * Implementations typically convert/apply [customKeys] and then record [exception].
+     *
+     * Supported value types
+     * Values should be one of: [String], [Boolean], [Int], [Long], [Float], [Double].
+     * Other types may be converted to string via `toString()` (or ignored), depending on platform.
+     *
+     * Notes
+     * Custom keys may affect subsequent reports depending on platform implementation.
+     * For persistent metadata, prefer [setCustomKeys] / [setCustomKey].
+     *
+     * @param exception A [Throwable] to be recorded as a non-fatal event.
+     * @param customKeys Key-value pairs to associate with this event context.
+     *
+     * @see setCustomKeys
+     * @see setCustomKey
+     */
+    public fun recordException(exception: Throwable, customKeys: Map<String, Any>)
+
+
+    /**
      * Logs a message that's included in the next fatal, non-fatal, or ANR report.
      *
      * Logs are visible in the session view on the Firebase Crashlytics console.

--- a/firebase-crashlytics/src/commonTest/kotlin/dev/gitlive/firebase/crashlytics/crashlytics.kt
+++ b/firebase-crashlytics/src/commonTest/kotlin/dev/gitlive/firebase/crashlytics/crashlytics.kt
@@ -51,6 +51,22 @@ class FirebaseCrashlyticsTest {
     }
 
     @Test
+    fun testRecordExceptionWithMap() = runTest {
+        val keys = mapOf<String, Any>(
+            "message" to "Test Exception",   // String
+            "enabled" to true,               // Boolean
+            "countInt" to 3,                 // Int
+            "countLong" to 3L,               // Long
+            "ratioFloat" to 0.75f,           // Float
+            "ratioDouble" to 3.141592,       // Double
+        )
+
+        crashlytics.recordException(Exception("Test Exception"), keys)
+        delay(1.seconds)
+    }
+
+
+    @Test
     fun testLog() = runTest {
         crashlytics.log("Test Log")
 


### PR DESCRIPTION
Add recordException(exception: Throwable, customKeys: Map<String, Any>) overload to attach custom key/value pairs when recording a non-fatal exception.