### PR TITLE
Fix custom parameters type for web platform

### DIFF
--- a/firebase-analytics/src/jsMain/kotlin/dev/gitlive/firebase/analytics/analytics.kt
+++ b/firebase-analytics/src/jsMain/kotlin/dev/gitlive/firebase/analytics/analytics.kt
@@ -7,6 +7,7 @@ import dev.gitlive.firebase.analytics.externals.getAnalytics
 import dev.gitlive.firebase.js
 import kotlinx.coroutines.await
 import kotlin.time.Duration
+import kotlin.js.json
 
 public actual val Firebase.analytics: FirebaseAnalytics
     get() = FirebaseAnalytics(getAnalytics())
@@ -20,7 +21,8 @@ public actual class FirebaseAnalytics(internal val js: dev.gitlive.firebase.anal
         name: String,
         parameters: Map<String, Any>?,
     ) {
-        dev.gitlive.firebase.analytics.externals.logEvent(js, name, parameters)
+        val json = json(*parameters?.map { it.key to it.value }.orEmpty().toTypedArray())
+        dev.gitlive.firebase.analytics.externals.logEvent(js, name, json)
     }
 
     public actual fun setUserProperty(name: String, value: String) {

--- a/firebase-analytics/src/jsMain/kotlin/dev/gitlive/firebase/analytics/externals/analytics.kt
+++ b/firebase-analytics/src/jsMain/kotlin/dev/gitlive/firebase/analytics/externals/analytics.kt
@@ -6,10 +6,11 @@ package dev.gitlive.firebase.analytics.externals
 
 import dev.gitlive.firebase.externals.FirebaseApp
 import kotlin.js.Promise
+import kotlin.js.Json
 
 public external fun getAnalytics(app: FirebaseApp? = definedExternally): FirebaseAnalytics
 
-public external fun logEvent(app: FirebaseAnalytics, name: String, parameters: Map<String, Any>?)
+public external fun logEvent(app: FirebaseAnalytics, name: String, parameters: Json?)
 public external fun setUserProperty(app: FirebaseAnalytics, name: String, value: String)
 public external fun setUserId(app: FirebaseAnalytics, id: String?)
 public external fun resetAnalyticsData(app: FirebaseAnalytics)


### PR DESCRIPTION
In regards to this issue: https://github.com/GitLiveApp/firebase-kotlin-sdk/issues/691

Custom parameters for web do not get logged correctly. Changing the custom parameters type from Map to Json fixes this.