### PR TITLE
Add Query.get() to Realtime Database

### DIFF
--- a/firebase-database/api/android/firebase-database.api
+++ b/firebase-database/api/android/firebase-database.api
@@ -93,6 +93,7 @@ public class dev/gitlive/firebase/database/Query {
 	public static synthetic fun equalTo$default (Ldev/gitlive/firebase/database/Query;DLjava/lang/String;ILjava/lang/Object;)Ldev/gitlive/firebase/database/Query;
 	public static synthetic fun equalTo$default (Ldev/gitlive/firebase/database/Query;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ldev/gitlive/firebase/database/Query;
 	public static synthetic fun equalTo$default (Ldev/gitlive/firebase/database/Query;ZLjava/lang/String;ILjava/lang/Object;)Ldev/gitlive/firebase/database/Query;
+	public final fun get (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getPersistenceEnabled ()Z
 	public final fun getValueEvents ()Lkotlinx/coroutines/flow/Flow;
 	public final fun limitToFirst (I)Ldev/gitlive/firebase/database/Query;

--- a/firebase-database/api/jvm/firebase-database.api
+++ b/firebase-database/api/jvm/firebase-database.api
@@ -93,6 +93,7 @@ public class dev/gitlive/firebase/database/Query {
 	public static synthetic fun equalTo$default (Ldev/gitlive/firebase/database/Query;DLjava/lang/String;ILjava/lang/Object;)Ldev/gitlive/firebase/database/Query;
 	public static synthetic fun equalTo$default (Ldev/gitlive/firebase/database/Query;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ldev/gitlive/firebase/database/Query;
 	public static synthetic fun equalTo$default (Ldev/gitlive/firebase/database/Query;ZLjava/lang/String;ILjava/lang/Object;)Ldev/gitlive/firebase/database/Query;
+	public final fun get (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getPersistenceEnabled ()Z
 	public final fun getValueEvents ()Lkotlinx/coroutines/flow/Flow;
 	public final fun limitToFirst (I)Ldev/gitlive/firebase/database/Query;

--- a/firebase-database/src/androidMain/kotlin/dev/gitlive/firebase/database/database.kt
+++ b/firebase-database/src/androidMain/kotlin/dev/gitlive/firebase/database/database.kt
@@ -199,6 +199,16 @@ public actual open class Query internal actual constructor(
         awaitClose { android.removeEventListener(listener) }
     }
 
+    public actual suspend fun get(): DataSnapshot {
+        val deferred = CompletableDeferred<DataSnapshot>()
+        android.get().addOnSuccessListener { snapshot ->
+            deferred.complete(DataSnapshot(snapshot, persistenceEnabled))
+        }.addOnFailureListener { exception ->
+            deferred.completeExceptionally(exception)
+        }
+        return deferred.await()
+    }
+
     override fun toString(): String = android.toString()
 }
 

--- a/firebase-database/src/androidMain/kotlin/dev/gitlive/firebase/database/database.kt
+++ b/firebase-database/src/androidMain/kotlin/dev/gitlive/firebase/database/database.kt
@@ -201,11 +201,16 @@ public actual open class Query internal actual constructor(
 
     public actual suspend fun get(): DataSnapshot {
         val deferred = CompletableDeferred<DataSnapshot>()
-        android.get().addOnSuccessListener { snapshot ->
-            deferred.complete(DataSnapshot(snapshot, persistenceEnabled))
-        }.addOnFailureListener { exception ->
-            deferred.completeExceptionally(exception)
-        }
+        android.get()
+            .addOnSuccessListener { snapshot ->
+                deferred.complete(DataSnapshot(snapshot, persistenceEnabled))
+            }
+            .addOnFailureListener { exception ->
+                deferred.completeExceptionally(exception)
+            }
+            .addOnCanceledListener {
+                deferred.cancel()
+            }
         return deferred.await()
     }
 

--- a/firebase-database/src/appleMain/kotlin/dev/gitlive/firebase/database/database.kt
+++ b/firebase-database/src/appleMain/kotlin/dev/gitlive/firebase/database/database.kt
@@ -165,6 +165,18 @@ public actual open class Query internal actual constructor(
         }
     }
 
+    public actual suspend fun get(): DataSnapshot {
+        val deferred = CompletableDeferred<DataSnapshot>()
+        ios.getDataWithCompletionBlock { error, snapshot ->
+            if (error != null) {
+                deferred.completeExceptionally(DatabaseException(error.toString(), null))
+            } else {
+                deferred.complete(DataSnapshot(snapshot!!, persistenceEnabled))
+            }
+        }
+        return deferred.await()
+    }
+
     override fun toString(): String = ios.toString()
 }
 

--- a/firebase-database/src/commonMain/kotlin/dev/gitlive/firebase/database/database.kt
+++ b/firebase-database/src/commonMain/kotlin/dev/gitlive/firebase/database/database.kt
@@ -170,6 +170,12 @@ public expect open class Query internal constructor(nativeQuery: NativeQuery) {
     public fun childEvents(vararg types: ChildEvent.Type = arrayOf(ADDED, CHANGED, MOVED, REMOVED)): Flow<ChildEvent>
 
     /**
+     * Gets the server values for this query. Updates the cache and raises events if successful. If not
+     * connected, falls back to a locally-cached value or null.
+     */
+    public suspend fun get(): DataSnapshot
+
+    /**
      * Creates a query in which child nodes are ordered by their keys.
      *
      * @return A query with the new constraint

--- a/firebase-database/src/commonTest/kotlin/dev/gitlive/firebase/database/database.kt
+++ b/firebase-database/src/commonTest/kotlin/dev/gitlive/firebase/database/database.kt
@@ -80,6 +80,19 @@ class FirebaseDatabaseTest {
     }
 
     @Test
+    fun testGet() = runTest {
+        ensureDatabaseConnected()
+        val testValue = "testGetValue"
+        val testReference = database.reference("testGet")
+
+        testReference.setValue(testValue)
+
+        val snapshot = testReference.get()
+
+        assertEquals(testValue, snapshot.value<String>())
+    }
+
+    @Test
     fun testChildCount() = runTest {
         setupRealtimeData()
         val dataSnapshot = database

--- a/firebase-database/src/jsMain/kotlin/dev/gitlive/firebase/database/database.kt
+++ b/firebase-database/src/jsMain/kotlin/dev/gitlive/firebase/database/database.kt
@@ -14,6 +14,7 @@ import dev.gitlive.firebase.database.externals.Database
 import dev.gitlive.firebase.database.externals.child
 import dev.gitlive.firebase.database.externals.connectDatabaseEmulator
 import dev.gitlive.firebase.database.externals.enableLogging
+import dev.gitlive.firebase.database.externals.get
 import dev.gitlive.firebase.database.externals.getDatabase
 import dev.gitlive.firebase.database.externals.onChildAdded
 import dev.gitlive.firebase.database.externals.onChildChanged
@@ -143,6 +144,10 @@ public actual open class Query internal actual constructor(
             }
         }
         awaitClose { rethrow { unsubscribes.forEach { it.invoke() } } }
+    }
+
+    public actual suspend fun get(): DataSnapshot = rethrow {
+        DataSnapshot(get(publicJs).awaitWhileOnline(database), database)
     }
 
     public actual fun startAt(value: String, key: String?): Query = Query(query(publicJs, jsStartAt(value, key ?: undefined)), database)


### PR DESCRIPTION
## Summary

Adds `Query.get()` across Android, Apple, and JS. Previous implementations used `Query.valueEvents.first()` to fetch a single value, but that returns either local or remote data depending on whether persistence is enabled. `get()` always fetches from the server and falls back to the locally-cached value (or null) if offline, giving consistent behavior regardless of persistence settings.

Cancellation is supported. If the coroutine is cancelled while waiting, the underlying request is cancelled as well.

## Test plan

- [ ] Run existing firebase-database common tests
- [ ] Verify `Query.get()` returns remote data on Android, iOS, and JS
- [ ] Verify correct fallback behavior when offline
