### PR TITLE
Fix android phone authentication

### DIFF
--- a/firebase-auth/build.gradle.kts
+++ b/firebase-auth/build.gradle.kts
@@ -179,6 +179,16 @@ kotlin {
                     api(libs.google.firebase.auth)
                 }
             }
+
+            getByName("androidInstrumentedTest") {
+                dependencies {
+                    // phone auth registers an sms retriever via ContextCompat.registerReceiver(
+                    // Context, BroadcastReceiver, IntentFilter, Int), which firebase-auth calls but
+                    // does not pull in - without this the test apk resolves androidx.core 1.2.0 and
+                    // PhoneAuthTest fails with a NoSuchMethodError
+                    implementation(libs.androidx.core)
+                }
+            }
         }
     }
 }

--- a/firebase-auth/src/androidInstrumentedTest/AndroidManifest.xml
+++ b/firebase-auth/src/androidInstrumentedTest/AndroidManifest.xml
@@ -1,4 +1,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <application android:usesCleartextTraffic="true" />
+    <application android:usesCleartextTraffic="true">
+
+        <!-- phone auth requires an activity to attach app verification to, see PhoneAuthTest -->
+        <activity
+            android:name="android.app.Activity"
+            android:exported="false"
+            android:theme="@android:style/Theme.Material.Light.NoActionBar" />
+
+    </application>
 </manifest>

--- a/firebase-auth/src/androidInstrumentedTest/kotlin/dev/gitlive/firebase/auth/phoneAuth.kt
+++ b/firebase-auth/src/androidInstrumentedTest/kotlin/dev/gitlive/firebase/auth/phoneAuth.kt
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2020 GitLive Ltd.  Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package dev.gitlive.firebase.auth
+
+import android.app.Activity
+import androidx.test.core.app.ActivityScenario
+import dev.gitlive.firebase.Firebase
+import dev.gitlive.firebase.FirebaseOptions
+import dev.gitlive.firebase.apps
+import dev.gitlive.firebase.initialize
+import dev.gitlive.firebase.runBlockingTest
+import dev.gitlive.firebase.runTest
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+import java.net.URL
+import java.util.concurrent.TimeUnit
+import kotlin.random.Random
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
+
+/**
+ * Phone auth cannot be covered from commonTest like the rest of the auth suite: [PhoneAuthProvider]
+ * requires an [Activity] to attach app verification to, and [PhoneVerificationProvider] exposes
+ * different members on every platform, so there is no shared surface to test against.
+ *
+ * No sms is sent - the auth emulator records the code it would have sent and serves it back over its
+ * rest api, which is what [TestPhoneVerificationProvider] reads instead of prompting a user.
+ */
+class PhoneAuthTest {
+
+    private companion object {
+        const val PROJECT_ID = "fir-kotlin-sdk"
+        const val AUTH_EMULATOR_PORT = 9099
+
+        /**
+         * Deliberately long, so that a regression which only asks for the code once auto retrieval
+         * has timed out is clearly distinguishable from one which asks as soon as it is sent.
+         */
+        const val AUTO_RETRIEVAL_TIMEOUT_SECONDS = 120L
+    }
+
+    private lateinit var auth: FirebaseAuth
+    private lateinit var scenario: ActivityScenario<Activity>
+    private lateinit var activity: Activity
+
+    @BeforeTest
+    fun initializeFirebase() {
+        val app = Firebase.apps(context).firstOrNull() ?: Firebase.initialize(
+            context,
+            FirebaseOptions(
+                applicationId = "1:846484016111:ios:dd1f6688bad7af768c841a",
+                apiKey = "AIzaSyCK87dcMFhzCz_kJVs2cT2AVlqOTLuyWV0",
+                databaseUrl = "https://fir-kotlin-sdk.firebaseio.com",
+                storageBucket = "fir-kotlin-sdk.appspot.com",
+                projectId = PROJECT_ID,
+                gcmSenderId = "846484016111",
+            ),
+        )
+
+        auth = Firebase.auth(app).apply {
+            useEmulator(emulatorHost, AUTH_EMULATOR_PORT)
+            // there is no play services attestation on a test device, so skip app verification
+            android.firebaseAuthSettings.setAppVerificationDisabledForTesting(true)
+        }
+
+        scenario = ActivityScenario.launch(Activity::class.java)
+        scenario.onActivity { activity = it }
+    }
+
+    @AfterTest
+    fun deinitializeFirebase() = runBlockingTest {
+        scenario.close()
+        Firebase.apps(context).forEach {
+            it.delete()
+        }
+    }
+
+    @Test
+    fun testVerificationCodeIsRequestedAsSoonAsTheCodeIsSent() = runTest {
+        val phoneNumber = randomPhoneNumber()
+        val verificationProvider = TestPhoneVerificationProvider(phoneNumber)
+
+        val startedAt = TimeSource.Monotonic.markNow()
+        val credential = PhoneAuthProvider(auth).verifyPhoneNumber(phoneNumber, verificationProvider)
+        val elapsed = startedAt.elapsedNow()
+
+        assertNotNull(credential)
+        assertEquals(1, verificationProvider.codesSent)
+        // the code used to only be requested from onCodeAutoRetrievalTimeOut, which blocked the
+        // caller for the full auto retrieval timeout before the user could enter anything
+        assertTrue(
+            elapsed < (AUTO_RETRIEVAL_TIMEOUT_SECONDS / 4).seconds,
+            "expected the code to be requested as soon as it was sent, but verification took $elapsed",
+        )
+    }
+
+    @Test
+    fun testCodeIsSubmittedAgainstTheVerificationIdOfTheMostRecentResend() = runTest {
+        val phoneNumber = randomPhoneNumber()
+        val verificationProvider = TestPhoneVerificationProvider(phoneNumber, resendOnFirstCode = true)
+
+        val credential = PhoneAuthProvider(auth).verifyPhoneNumber(phoneNumber, verificationProvider)
+
+        assertEquals(2, verificationProvider.codesSent)
+        // resending issues a new verification id and invalidates the previous one, so signing in
+        // only succeeds if the code was paired with the newer of the two
+        val result = auth.signInWithCredential(credential)
+        try {
+            assertNotNull(result.user)
+        } finally {
+            result.user?.delete()
+        }
+    }
+
+    private fun randomPhoneNumber() = "+1555555${Random.nextInt(1000, 10000)}"
+
+    private inner class TestPhoneVerificationProvider(
+        private val phoneNumber: String,
+        private val resendOnFirstCode: Boolean = false,
+    ) : PhoneVerificationProvider {
+
+        override val activity: Activity get() = this@PhoneAuthTest.activity
+        override val timeout: Long = AUTO_RETRIEVAL_TIMEOUT_SECONDS
+        override val unit: TimeUnit = TimeUnit.SECONDS
+
+        var codesSent = 0
+            private set
+
+        /** completed once no further verification ids are expected */
+        private val settled = CompletableDeferred<Unit>()
+
+        override fun codeSent(triggerResend: (Unit) -> Unit) {
+            codesSent++
+            if (resendOnFirstCode && codesSent == 1) {
+                triggerResend(Unit)
+            } else {
+                settled.complete(Unit)
+            }
+        }
+
+        override suspend fun getVerificationCode(): String {
+            // stand in for the user taking long enough to type that the resend has landed
+            settled.await()
+            return latestVerificationCode()
+        }
+
+        private suspend fun latestVerificationCode(): String = withContext(Dispatchers.IO) {
+            val url = "http://$emulatorHost:$AUTH_EMULATOR_PORT/emulator/v1/projects/$PROJECT_ID/verificationCodes"
+            repeat(10) {
+                val codes = JSONObject(URL(url).readText()).getJSONArray("verificationCodes")
+                for (index in codes.length() - 1 downTo 0) {
+                    val code = codes.getJSONObject(index)
+                    if (code.getString("phoneNumber") == phoneNumber) {
+                        return@withContext code.getString("code")
+                    }
+                }
+                delay(500)
+            }
+            error("the auth emulator recorded no verification code for $phoneNumber")
+        }
+    }
+}

--- a/firebase-auth/src/androidMain/kotlin/dev/gitlive/firebase/auth/credentials.kt
+++ b/firebase-auth/src/androidMain/kotlin/dev/gitlive/firebase/auth/credentials.kt
@@ -10,8 +10,12 @@ import com.google.firebase.auth.OAuthProvider as AndroidOAuthProvider
 import com.google.firebase.auth.PhoneAuthOptions
 import com.google.firebase.auth.PhoneAuthProvider
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.selects.select
+import kotlinx.coroutines.supervisorScope
 import java.util.concurrent.TimeUnit
 
 public actual open class AuthCredential(public open val android: com.google.firebase.auth.AuthCredential) {
@@ -86,12 +90,17 @@ public actual class PhoneAuthProvider(public val createOptionsBuilder: () -> Pho
 
     public actual fun credential(verificationId: String, smsCode: String): PhoneAuthCredential = PhoneAuthCredential(PhoneAuthProvider.getCredential(verificationId, smsCode))
 
-    public actual suspend fun verifyPhoneNumber(phoneNumber: String, verificationProvider: PhoneVerificationProvider): AuthCredential = coroutineScope {
-        val response = CompletableDeferred<Result<AuthCredential>>()
+    // unlike the other platforms android can complete the verification without any user input, via
+    // sms auto retrieval, so the credential is whichever of the two arrives first
+    public actual suspend fun verifyPhoneNumber(phoneNumber: String, verificationProvider: PhoneVerificationProvider): AuthCredential = supervisorScope {
+        // resending replaces the verification id and invalidates the previous one
+        val latestVerificationId = MutableStateFlow<String?>(null)
+        val autoRetrieved = CompletableDeferred<AuthCredential>()
         val callback = object :
             PhoneAuthProvider.OnVerificationStateChangedCallbacks() {
 
             override fun onCodeSent(verificationId: String, forceResending: PhoneAuthProvider.ForceResendingToken) {
+                latestVerificationId.value = verificationId
                 verificationProvider.codeSent {
                     val options = createOptionsBuilder()
                         .setPhoneNumber(phoneNumber)
@@ -104,23 +113,12 @@ public actual class PhoneAuthProvider(public val createOptionsBuilder: () -> Pho
                 }
             }
 
-            override fun onCodeAutoRetrievalTimeOut(verificationId: String) {
-                launch {
-                    val code = verificationProvider.getVerificationCode()
-                    try {
-                        response.complete(Result.success(credential(verificationId, code)))
-                    } catch (e: Exception) {
-                        response.complete(Result.failure(e))
-                    }
-                }
-            }
-
             override fun onVerificationCompleted(credential: com.google.firebase.auth.PhoneAuthCredential) {
-                response.complete(Result.success(AuthCredential(credential)))
+                autoRetrieved.complete(AuthCredential(credential))
             }
 
             override fun onVerificationFailed(error: FirebaseException) {
-                response.complete(Result.failure(error))
+                autoRetrieved.completeExceptionally(error)
             }
         }
         val options = createOptionsBuilder()
@@ -131,7 +129,25 @@ public actual class PhoneAuthProvider(public val createOptionsBuilder: () -> Pho
             .build()
         PhoneAuthProvider.verifyPhoneNumber(options)
 
-        response.await().getOrThrow()
+        val userEntered = async {
+            // prompt as soon as a code has been sent rather than waiting for auto retrieval to time
+            // out, as recommended by
+            // https://firebase.google.com/docs/auth/android/phone-auth#oncodeautoretrievaltimeoutstring-verificationid
+            latestVerificationId.filterNotNull().first()
+            val code = verificationProvider.getVerificationCode()
+            credential(checkNotNull(latestVerificationId.value), code)
+        }
+
+        try {
+            select {
+                autoRetrieved.onAwait { it }
+                userEntered.onAwait { it }
+            }
+        } finally {
+            // select does not cancel the losing clause, and a code entry still waiting on the user
+            // would otherwise keep this scope alive after auto retrieval has already completed
+            userEntered.cancel()
+        }
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "8.12.0"
+androidx-core = "1.13.1"
 androidx-test-core = "1.7.0"
 androidx-test-junit = "1.3.0"
 androidx-test-runner = "1.7.0"
@@ -26,6 +27,7 @@ publish = "0.34.0"
 
 [libraries]
 android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }
+androidx-core = { module = "androidx.core:core", version.ref = "androidx-core" }
 androidx-test-core = { module = "androidx.test:core", version.ref = "androidx-test-core" }
 androidx-test-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-test-junit" }
 androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidx-test-runner" }


### PR DESCRIPTION
Supersedes #308 by @CharlesEtieve, rebased onto current master and with the review feedback applied. Original commit preserved as a co-author trailer.

### The bug

`getVerificationCode()` was called from `onCodeAutoRetrievalTimeOut`, so the user could not enter the sms code until the auto retrieval timeout had elapsed. The [firebase documentation](https://firebase.google.com/docs/auth/android/phone-auth#oncodeautoretrievaltimeoutstring-verificationid) recommends enabling input once the code has been sent.

To answer the question left open on #308 — **no, ios and js are not affected.** Both resolve a verification id and then ask for the code immediately, so they have always had the intended behaviour. This only brings android into line with them.

### Review feedback from #308

- **"we shouldn't be wrapping the result in a `Result`"** — the deferred is now `CompletableDeferred<AuthCredential>` and failures use `completeExceptionally`.
- **"we'll need to fail the CompletableDeferred otherwise it will hang"** — the hang was real, but failing on auto retrieval timeout would have reintroduced the original bug, which is what @CharlesEtieve pushed back on at the time. The cause is that `coroutineScope` does not return until every child completes: once code entry is launched from `onCodeSent`, a *successful* auto retrieval completes the verification while that coroutine is still suspended on the user, and the scope never closes. It is now cancelled in a `finally` instead.

### Implementation

Android is the only platform that can complete verification with no user input, so the two outcomes race explicitly, in the same style as `awaitWhileOnline` in firebase-database:

```kotlin
select {
    autoRetrieved.onAwait { it }
    userEntered.onAwait { it }
}
```

`select` does not cancel the losing clause, hence the explicit cancel. `supervisorScope` rather than `coroutineScope` so that a code entry which fails *after* auto retrieval has already won cannot turn a successful verification into a failure.

The verification id is held in a `MutableStateFlow` and read at submit time, because resending issues a new id and invalidates the previous one — neither #308 nor the first draft of this change handled that.

### Tests

Two instrumented tests against the auth emulator, which records the code it would have sent rather than sending an sms:

- prompt timing — asserts verification completes well inside the auto retrieval timeout
- resend — asserts the code is paired with the newest verification id

These cannot live in `commonTest`: an `Activity` is required, and `PhoneVerificationProvider` exposes different members on every platform.

**Not covered:** the hang itself. That needs `onVerificationCompleted` to fire with no user input, which the emulator never does, and there is no seam to drive the callbacks synthetically — `PhoneAuthProvider.verifyPhoneNumber` is a static call into the sdk. Covering it would mean extracting callback delivery behind an injectable interface, which is worth doing separately.

Public api is unchanged; `androidApiCheck` and `jvmApiCheck` both pass with no dump changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)