### PR TITLE
Fix lintAndApiChecks for pull requests from forks

### DIFF
--- a/.github/workflows/pull_request_target.yml
+++ b/.github/workflows/pull_request_target.yml
@@ -66,8 +66,33 @@ jobs:
           done
 
           echo "Running API dump tasks:$api_dump_tasks"
+          echo "API_DUMP_TASKS=$api_dump_tasks" >> "$GITHUB_ENV"
           ./gradlew $api_dump_tasks
 
       - run: git status
 
+      # Fork PRs run with a read-only GITHUB_TOKEN, and their head branch does not
+      # exist in this repo, so the auto-commit below cannot work. Verify instead and
+      # tell the contributor what to run locally.
+      - name: Verify formatting and API files are up to date
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          # Match what git-auto-commit-action would have staged (file_pattern
+          # defaults to "."), so tracked edits and new API files both count.
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::error::Formatting or API dump files are out of date."
+            echo "This PR comes from a fork, so CI cannot update them for you."
+            echo "Run the following locally and commit the result:"
+            echo "  ./gradlew formatKotlin"
+            echo "  ./gradlew$API_DUMP_TASKS"
+            echo ""
+            echo "Files that differ:"
+            git status --porcelain
+            exit 1
+          fi
+          echo "Formatting and API files are up to date."
+
       - uses: stefanzweifel/git-auto-commit-action@v7
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        with:
+          branch: ${{ github.head_ref }}


### PR DESCRIPTION
## Problem

`lintAndApiChecks` fails on **every pull request from a fork**, while passing for same-repo branches such as dependabot's.

The job runs `formatKotlin` and the `apiDump` tasks, then pushes the result back with `stefanzweifel/git-auto-commit-action`. That action defaults its `branch` input to `github.head_ref`, which for a fork PR names a branch in the *contributor's* fork, not this repo. The step aborts:

```
INPUT_BRANCH value: feature/database-transaction
fatal: invalid reference: feature/database-transaction
Error: Invalid status code: 128
```

Fork PRs also run with a read-only `GITHUB_TOKEN` under the `pull_request` trigger, so the push could not have succeeded even with a valid ref.

Seen on #820, where the other 5 checks pass and the contributor had already updated both `.api` dumps correctly. It affects the rest of the external queue too — #784, #785, #807, #824, #832, #840 are all forks.

## Fix

- Same-repo PRs: unchanged, still auto-commits. `branch:` is now set explicitly to the action's existing default so the distinction is visible at the call site.
- Fork PRs: skip the push. Run the same format and dump steps, then fail if the tree is dirty, printing the exact gradle commands to run locally.

`api_dump_tasks` was a shell local, so it is now exported via `$GITHUB_ENV` to let the error message name the real tasks. The check uses `git status --porcelain` rather than `git diff --quiet` so that newly added API files count, matching what the action would have staged (`file_pattern` defaults to `.`).

## Verification

YAML parses, the two guards are exact complements, and the guard values were confirmed against the live API (`pmodernme/firebase-kotlin-sdk` vs `GitLiveApp/firebase-kotlin-sdk`). The verify-step shell logic was exercised in a scratch repo: clean tree passes, dirty tree fails with the interpolated task list, a new untracked `.api` file is caught, gitignored build output is not.

The fork path cannot be exercised until this is on master, since the workflow only runs on `pull_request`. **#820 is the natural canary.**

Note: this file is named `pull_request_target.yml` but triggers on `pull_request`. Left alone deliberately — `pull_request_target` would run untrusted fork code with a write-scoped token, so the current trigger is the safer one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)