### PR TITLE
Fix Firebase.remoteConfig(app) ignoring the given app on Apple targets

### DIFF
--- a/firebase-config/src/appleMain/kotlin/dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfig.kt
+++ b/firebase-config/src/appleMain/kotlin/dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfig.kt
@@ -11,7 +11,6 @@ import cocoapods.FirebaseRemoteConfig.FIRRemoteConfigSource
 import dev.gitlive.firebase.Firebase
 import dev.gitlive.firebase.FirebaseApp
 import dev.gitlive.firebase.FirebaseException
-import dev.gitlive.firebase.app
 import dev.gitlive.firebase.ios
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.datetime.Instant
@@ -28,7 +27,7 @@ public actual val Firebase.remoteConfig: FirebaseRemoteConfig
     get() = FirebaseRemoteConfig(FIRRemoteConfig.remoteConfig())
 
 public actual fun Firebase.remoteConfig(app: FirebaseApp): FirebaseRemoteConfig = FirebaseRemoteConfig(
-    FIRRemoteConfig.remoteConfigWithApp(Firebase.app.ios as objcnames.classes.FIRApp),
+    FIRRemoteConfig.remoteConfigWithApp(app.ios as objcnames.classes.FIRApp),
 )
 
 public actual class FirebaseRemoteConfig internal constructor(internal val ios: FIRRemoteConfig) {

--- a/firebase-config/src/commonTest/kotlin/dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfig.kt
+++ b/firebase-config/src/commonTest/kotlin/dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfig.kt
@@ -31,21 +31,20 @@ class FirebaseRemoteConfigTest {
         "test_default_string" to "Hello World",
     )
 
+    private val options = FirebaseOptions(
+        applicationId = "1:846484016111:ios:dd1f6688bad7af768c841a",
+        apiKey = "AIzaSyCK87dcMFhzCz_kJVs2cT2AVlqOTLuyWV0",
+        databaseUrl = "https://fir-kotlin-sdk.firebaseio.com",
+        storageBucket = "fir-kotlin-sdk.appspot.com",
+        projectId = "fir-kotlin-sdk",
+        gcmSenderId = "846484016111",
+    )
+
     lateinit var remoteConfig: FirebaseRemoteConfig
 
     @BeforeTest
     fun initializeFirebase() {
-        val app = Firebase.apps(context).firstOrNull() ?: Firebase.initialize(
-            context,
-            FirebaseOptions(
-                applicationId = "1:846484016111:ios:dd1f6688bad7af768c841a",
-                apiKey = "AIzaSyCK87dcMFhzCz_kJVs2cT2AVlqOTLuyWV0",
-                databaseUrl = "https://fir-kotlin-sdk.firebaseio.com",
-                storageBucket = "fir-kotlin-sdk.appspot.com",
-                projectId = "fir-kotlin-sdk",
-                gcmSenderId = "846484016111",
-            ),
-        )
+        val app = Firebase.apps(context).firstOrNull() ?: Firebase.initialize(context, options)
 
         remoteConfig = Firebase.remoteConfig(app)
     }
@@ -111,6 +110,29 @@ class FirebaseRemoteConfigTest {
             ).toString(),
             remoteConfig.info.toString(),
         )
+    }
+
+    // Regression test for #707. On Apple the `app` argument used to be ignored in favour of the
+    // default app, so this returned the default app's instance (and threw an NPE outright when no
+    // default app existed). Every other test here passes the default app, so none of them could
+    // have caught it.
+    @Test
+    fun testRemoteConfigUsesGivenApp() = runTest {
+        val secondaryApp = Firebase.initialize(context, options, "secondary")
+        val secondaryConfig = Firebase.remoteConfig(secondaryApp)
+        try {
+            secondaryConfig.setDefaults("test_secondary_only" to "secondary value")
+
+            val onSecondary = secondaryConfig.getValue("test_secondary_only")
+            assertEquals("secondary value", onSecondary.asString())
+            assertEquals(ValueSource.Default, onSecondary.getSource())
+
+            // A distinct instance, so the default just set must not exist on the default app at
+            // all. Static is the source reported for a key that was never set.
+            assertEquals(ValueSource.Static, remoteConfig.getValue("test_secondary_only").getSource())
+        } finally {
+            secondaryConfig.reset()
+        }
     }
 
     @Test


### PR DESCRIPTION
Fixes #707.

## Problem

On Apple targets `Firebase.remoteConfig(app)` ignored its `app` argument and built the instance from the **default** app instead:

```kotlin
public actual fun Firebase.remoteConfig(app: FirebaseApp): FirebaseRemoteConfig = FirebaseRemoteConfig(
    FIRRemoteConfig.remoteConfigWithApp(Firebase.app.ios as objcnames.classes.FIRApp),
)
```

Two consequences:

1. **Wrong instance.** A caller passing a secondary app silently received the default app's Remote Config.
2. **Crash when there is no default app.** `Firebase.app` on Apple is `FirebaseApp(FIRApp.defaultApp()!!)`, so the `!!` throws — which is exactly the `ThrowNullPointerException` → `<get-app>` → `remoteConfig` frames in the reported stack trace.

`firebase-config` was the only module with this problem: `auth`, `firestore`, `storage`, `database`, `functions` and `installations` all already pass the given app through on Apple, as do the Android and JS implementations of `remoteConfig(app)`.

## Fix

Use the `app` parameter, as @jimmymorales suggested in the issue. The `dev.gitlive.firebase.app` import becomes unused and is removed with it.

## Test

Added `testRemoteConfigUsesGivenApp`: it initialises a secondary app, sets a default on that app's Remote Config, and asserts the default app's instance does not see it.

It is worth saying why this needed a *new* test rather than extending an existing one. Every other test in `FirebaseRemoteConfigTest` passes the **default** app, so they pass identically with and without this change — none of them could have caught the bug. The new test fails on `master` (both handles are the same underlying instance, so the default leaks across) and passes with this fix.

I also pulled the `FirebaseOptions` literal out of `@BeforeTest` into a property so the new test can create the secondary app with the same options; that part is a pure move.

## What I could and could not verify

Being upfront: I was **not** able to run the Apple build or test suite locally — Gradle dependency resolution kept failing and then stalling in my environment, so I never got a green (or red) local run. Please treat CI as the real check on the new test.

What I did verify by reading the code rather than running it:

- `Firebase.app` on Apple is `FirebaseApp(FIRApp.defaultApp()!!)`, so the `!!` is the source of the reported NPE.
- The change is type-identical: `Firebase.app` returns a `FirebaseApp` and `app` *is* a `FirebaseApp`, and both use the same `FirebaseApp.ios` extension, so the expression type is unchanged.
- `dev.gitlive.firebase.app` was imported solely for the line being changed, so removing it leaves nothing unresolved.
- Every symbol the new test uses exists in the common API: `Firebase.initialize(context, options, name)`, `setDefaults(vararg Pair<String, Any?>)` and `reset()` (both `suspend`, called inside `runTest`), `getValue(key)`, and `ValueSource`.
- `asString()` returns `""` for an unset key on both Apple (`ios.stringValue ?: ""`) and Android, and `getSource()` reports `Static` for a key that was never set — which is what the test asserts on the default app's instance.
- No `max_line_length` is configured in `.editorconfig` and existing lines in these files reach 126 characters, so the added lines are within the file's norms.

## Notes on things I deliberately did not change

- The public `FirebaseRemoteConfig.ios` extension returns `FIRRemoteConfig.remoteConfig()` — the default instance — rather than the receiver's own, so `Firebase.remoteConfig(secondaryApp).ios` still hands back the default app's config. `firebase-storage`, `firebase-installations` and `firebase-functions` all follow the same pattern, so this looks like a repo-wide convention rather than something specific to this issue. Happy to follow up separately if you'd like it addressed.
- `Firebase.crashlytics(app)`, `Firebase.analytics(app)` and `Firebase.performance(app)` also ignore their `app` argument on Apple, but there the underlying iOS SDKs expose only a singleton (`FIRCrashlytics.crashlytics()`, `FIRAnalytics`, `FIRPerformance.sharedInstance()`), so there is nothing to pass through.
