### PR TITLE
Fix RemoteConfig.all returning defaults instead of fetched values on Apple

### DIFF
--- a/firebase-config/src/appleMain/kotlin/dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfig.kt
+++ b/firebase-config/src/appleMain/kotlin/dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfig.kt
@@ -35,14 +35,18 @@ public actual class FirebaseRemoteConfig internal constructor(internal val ios: 
     @Suppress("UNCHECKED_CAST")
     public actual val all: Map<String, FirebaseRemoteConfigValue>
         get() {
-            return listOf(
+            val keys = listOf(
                 FIRRemoteConfigSource.FIRRemoteConfigSourceStatic,
                 FIRRemoteConfigSource.FIRRemoteConfigSourceRemote,
                 FIRRemoteConfigSource.FIRRemoteConfigSourceDefault,
-            ).map { source ->
-                val keys = ios.allKeysFromSource(source) as List<String>
-                keys.map { it to FirebaseRemoteConfigValue(ios.configValueForKey(it, source)) }
-            }.flatten().toMap()
+            ).flatMapTo(mutableSetOf()) { source ->
+                ios.allKeysFromSource(source) as List<String>
+            }
+            // Resolve each key without pinning it to a source so that Firebase applies its own
+            // precedence (remote > default > static). Reading each source separately and merging
+            // the results let the last source listed win, which shadowed fetched remote values
+            // with the defaults.
+            return keys.associateWith { getValue(it) }
         }
 
     @OptIn(ExperimentalTime::class)

--- a/firebase-config/src/commonTest/kotlin/dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfig.kt
+++ b/firebase-config/src/commonTest/kotlin/dev/gitlive/firebase/remoteconfig/FirebaseRemoteConfig.kt
@@ -148,11 +148,17 @@ class FirebaseRemoteConfigTest {
         remoteConfig.settings {
             minimumFetchInterval = 1.minutes
         }
+        // A default stored under the same key as the remote value, so this also covers precedence:
+        // the fetched remote value has to win over the local default (#427).
+        remoteConfig.setDefaults("test_remote_string" to "Local default")
 
         remoteConfig.fetchAndActivate()
 
         val value: FirebaseRemoteConfigValue = remoteConfig["test_remote_string"]
         assertEquals("Hello from remote!", value.asString())
         assertEquals(ValueSource.Remote, value.getSource())
+
+        // `all` has to apply the same precedence as `getValue` does.
+        assertEquals("Hello from remote!", remoteConfig.all["test_remote_string"]?.asString())
     }
 }


### PR DESCRIPTION
Fixes #427.

## Problem

On Apple targets, `FirebaseRemoteConfig.all` read every key once *per source* and merged the results:

```kotlin
return listOf(
    FIRRemoteConfigSource.FIRRemoteConfigSourceStatic,
    FIRRemoteConfigSource.FIRRemoteConfigSourceRemote,
    FIRRemoteConfigSource.FIRRemoteConfigSourceDefault,   // <- last
).map { source ->
    val keys = ios.allKeysFromSource(source) as List<String>
    keys.map { it to FirebaseRemoteConfigValue(ios.configValueForKey(it, source)) }
}.flatten().toMap()
```

Two things combine badly here:

1. each value is fetched **pinned to a specific source** via `configValueForKey(key, source)`, so it bypasses Remote Config's own precedence; and
2. `toMap()` keeps the *last* pair for a duplicate key, and `Default` is listed last.

So for any key present in both the remote and default sources, `all` returns the **default**, shadowing the value that was just fetched.

That matches the report exactly: with `setDefaults(...)` the reporter saw stale defaults out of `all` even though the logs showed a successful fetch and activate, and removing `setDefaults(...)` made the remote values appear — because with no defaults registered there is no colliding key to overwrite them.

The documented precedence is remote > default > static, so this is backwards.

Apple was the only target with the problem:

- **JS** already does the right thing: `getAllKeys().associateWith { getValue(it) }`
- **Android** delegates to the native `all`, which applies precedence itself

## Fix

Collect the key set across the three sources, then resolve each key through `configValueForKey(key)` — the single-argument overload the class already uses in `getValue()` — so Firebase applies its own precedence. This is the same shape as the JS implementation.

`getKeysByPrefix()` is implemented on top of `all`, so it was affected the same way and is fixed by the same change.

## On testing

**I could not run the build or the tests locally** — Gradle dependency resolution stalls in my environment and I never got a green or red run, the same as I noted on #847. Please treat CI as the real check.

More importantly, this is not something the existing suite could have caught, and I want to be explicit about why rather than imply otherwise. `testGetAll` only calls `setDefaults(...)` and never fetches, so every key comes from the default source alone — there is no collision, and the test passes identically before and after this change. A genuine regression test needs a key that exists in *both* the remote and default sources, which means real remote values; that is exactly why `testFetch` and `testFetchAndActivate` are `@Ignore`d, since Remote Config isn't covered by the Firebase emulator.

So rather than add a test that cannot fail, I extended the existing `@Ignore`d `testFetchAndActivate` to register a default under the same key as the remote value and assert that `all` agrees with `getValue`. It won't run in CI, but it encodes the regression and makes it verifiable by anyone running that test manually against a project with the console value set.

Happy to take a different approach if you'd prefer the precedence pinned by an explicitly ordered merge instead of delegating to `configValueForKey(key)`.
