### PR TITLE
Fix putFileResumable failing on a successful upload on Apple targets

### DIFF
--- a/firebase-storage/src/appleMain/kotlin/dev/gitlive/firebase/storage/storage.kt
+++ b/firebase-storage/src/appleMain/kotlin/dev/gitlive/firebase/storage/storage.kt
@@ -192,7 +192,7 @@ public actual class StorageReference(internal val ios: FIRStorageReference) {
                 val progress = it!!.progress()!!
                 trySendBlocking(Progress.Running(progress.completedUnitCount, progress.totalUnitCount))
             }
-            ios.observeStatus(FIRStorageTaskStatusSuccess) { close(FirebaseStorageException(it!!.error().toString())) }
+            ios.observeStatus(FIRStorageTaskStatusSuccess) { close() }
             ios.observeStatus(FIRStorageTaskStatusFailure) {
                 when (it!!.error()!!.code) {
                     /*FIRStorageErrorCodeCancelled = */


### PR DESCRIPTION
Fixes #722.

## Problem

On Apple targets, `putFileResumable` closed its `ProgressFlow` with an exception when the upload **succeeded**:

```kotlin
ios.observeStatus(FIRStorageTaskStatusSuccess) { close(FirebaseStorageException(it!!.error().toString())) }
```

A success snapshot has no error, so `it.error()` is `null` and the collector received a `FirebaseStorageException` whose message was the string `"null"`. That's exactly what @zacsst reported — an error on completion, and "if i swallow it, the file was successfully uploaded", because by then the upload really had finished.

## Why this is unambiguous

`putDataResumable` sits 35 lines above in the same file and is otherwise identical to `putFileResumable` — same four `observeStatus` blocks, same `awaitClose`, same returned `ProgressFlow`. Its success handler is:

```kotlin
ios.observeStatus(FIRStorageTaskStatusSuccess) { close() }
```

So the correct code is already in the file; only `putFileResumable` got it wrong.

Android agrees on the intended semantics — its completion listener is `close(it.exception)`, and `it.exception` is `null` on success, which is a normal close:

```kotlin
val onCompleteListener = OnCompleteListener<UploadTask.TaskSnapshot> { close(it.exception) }
```

## Fix

One line: close the flow normally on success, matching `putDataResumable` and Android.

## On testing

Two things worth being explicit about rather than glossing over.

**I could not run the build or tests locally** — Gradle dependency resolution stalls in my environment and I never got a green or red run, same as I noted on #847 and #848. Please treat CI as the real check.

**No existing test could have caught this.** `commonTest` has `testPutDataResumable`, which does `ref.putDataResumable(data, metadata).collect {}` — a `collect` that would throw if the flow closed exceptionally, so it *is* the right shape of test. But it exercises `putDataResumable`, the method that was already correct. There is no `putFileResumable` equivalent.

I didn't add one because it needs more than a copy-paste: `File` is platform-specific (`File(NSURL)` on Apple, `File(Uri)` on Android), and `commonTest` currently has no way to produce one — there's no `File(` usage in any test source. Doing it properly means an `expect fun createTestFile(): File` in `test-utils` with an actual per target that writes a temp file, which is a bigger change than this fix and one I'd rather not bundle in silently. Happy to do it as a follow-up if you'd like the coverage.
