### PR TITLE
Publish the Firebase BoM on the api variant so compile classpaths resolve

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -126,7 +126,10 @@ subprojects {
         dependencies {
             "commonMainImplementation"(libs.kotlinx.coroutines.core)
             "androidMainImplementation"(libs.kotlinx.coroutines.play.services)
-            "androidMainImplementation"(platform(libs.firebase.bom))
+            // api, not implementation: the Firebase artifacts are declared with `api` and without a
+            // version, so the BoM has to reach the api variant as well or a consumer resolving the
+            // compile classpath has nothing to supply the version from.
+            "androidMainApi"(platform(libs.firebase.bom))
             "commonTestImplementation"(kotlin("test-common"))
             "commonTestImplementation"(kotlin("test-annotations-common"))
             if (this@afterEvaluate.name != "firebase-crashlytics") {


### PR DESCRIPTION
Fixes #356.

## Problem

The Google Firebase artifacts are declared with `api` and **no version**, because their versions come from the BoM:

```kotlin
// firebase-app/build.gradle.kts:174 (and equivalents in every module)
api(libs.google.firebase.common)
```

But the BoM itself was declared with `implementation`:

```kotlin
// build.gradle.kts:129
"androidMainImplementation"(platform(libs.firebase.bom))
```

`implementation` puts it in `runtimeElements` only. The result is visible in the published metadata for `dev.gitlive:firebase-app-android:2.5.0`:

```
releaseApiElements-published
    com.google.firebase:firebase-common      version = (none)      <- nothing to resolve it

releaseRuntimeElements-published
    com.google.firebase:firebase-common      version = (none)
    com.google.firebase:firebase-bom         platform, requires 33.15.0
```

So a consumer resolving a **compile** classpath gets `firebase-common` with no version and no constraint to supply one, and the build fails with:

```
Could not find com.google.firebase:firebase-common:.
```

Note the trailing colon with nothing after it — that's the missing version. Runtime classpaths resolve fine because the BoM is there, which is exactly why this only surfaces on compile/lint/androidTest configurations. The reporter's failure is on `debugAndroidTestCompileClasspath`.

It also explains why every workaround in that thread is a variation on supplying the version yourself:

- `api("com.google.firebase:firebase-common:20.3.1")` in `androidMain`
- `implementation(platform("com.google.firebase:firebase-bom:33.8.0"))` in the Android module

## Fix

Declare the BoM with `api` so the platform constraint reaches both variants. It's a single word.

## Verifying

I could not run the build locally — Gradle dependency resolution stalls in my environment and I never got a green or red run, the same as I noted on #847, #848 and #850. Please treat CI as the real check.

The meaningful verification for this change isn't a test though, it's the generated metadata. After the change, `firebase-app-android`'s `releaseApiElements-published` variant should gain the `com.google.firebase:firebase-bom` platform dependency it currently lacks — the same entry `releaseRuntimeElements-published` already has. That can be checked from a `publishToMavenLocal` without deploying anything:

```
./gradlew :firebase-app:publishToMavenLocal
python3 - <<'PY'
import json
d = json.load(open('<m2>/dev/gitlive/firebase-app-android/<version>/firebase-app-android-<version>.module'))
for v in d['variants']:
    print(v['name'], [x['module'] for x in v.get('dependencies', []) if 'bom' in x['module']])
PY
```

## Note

This is a different cause from #812, which has the same `Could not find com.google.firebase:...:` signature. There the artifact (`firebase-common-ktx`) had been removed by Firebase BoM 34; here the artifact exists but the constraint that versions it is missing from the api variant. Worth keeping distinct when triaging that error message.
