### PR TITLE
Document phone authentication and the per-platform PhoneVerificationProvider

### DIFF
--- a/firebase-auth/documentation.md
+++ b/firebase-auth/documentation.md
@@ -1,2 +1,75 @@
 # Module firebase-auth
 This module is a direct forward of the Firebase Authentication library. It provides the main functionality, like authenticating with Google or Apple.
+
+## Phone authentication
+
+`PhoneAuthProvider.verifyPhoneNumber` sends an SMS to the given number and suspends until it can return an `AuthCredential`, which you then pass to `signInWithCredential`:
+
+```kotlin
+val credential = PhoneAuthProvider().verifyPhoneNumber(phoneNumber, verificationProvider)
+Firebase.auth.signInWithCredential(credential)
+```
+
+The `PhoneVerificationProvider` you hand it is how the SDK asks your UI for the code the user received. `getVerificationCode` is called once the SMS has been sent, and should suspend until the user has entered it — typically by awaiting a `CompletableDeferred` that your code entry screen completes.
+
+### `PhoneVerificationProvider` is implemented per platform
+
+`PhoneVerificationProvider` is an `expect interface` with no common members, because each official Firebase SDK needs something different to start the flow. It therefore cannot be implemented in common code — declare your own `expect` function that returns one and write an `actual` for each platform you support.
+
+#### Android
+
+```kotlin
+class AndroidPhoneVerificationProvider(
+    override val activity: Activity,
+    private val code: CompletableDeferred<String>,
+) : PhoneVerificationProvider {
+    override val timeout: Long = 60
+    override val unit: TimeUnit = TimeUnit.SECONDS
+
+    override fun codeSent(triggerResend: (Unit) -> Unit) {
+        // Show your code entry UI here. Call triggerResend(Unit) to send a new SMS.
+    }
+
+    override suspend fun getVerificationCode(): String = code.await()
+}
+```
+
+Android is the only platform that can also complete the verification with no user input at all, via SMS auto retrieval. The SDK races auto retrieval against `getVerificationCode` and returns whichever arrives first, cancelling the other, so your code entry screen must tolerate being cancelled while it is still waiting on the user.
+
+`timeout` and `unit` bound that auto retrieval window; they do not bound how long the user has to type. Resending replaces the verification id and invalidates the previous one, which the SDK accounts for — the code you return is always submitted against the most recent id.
+
+#### Apple
+
+```kotlin
+class ApplePhoneVerificationProvider(
+    private val code: CompletableDeferred<String>,
+) : PhoneVerificationProvider {
+    override val delegate: FIRAuthUIDelegateProtocol? = null
+    override suspend fun getVerificationCode(): String = code.await()
+}
+```
+
+`delegate` is nullable and `null` is the normal choice. It is only used to present the `SFSafariViewController` that Firebase falls back to for reCAPTCHA verification when silent APNs verification is unavailable; passing `null` lets Firebase present it from your app's key window itself. Supply one only if you need to control which view controller presents it.
+
+There is no `timeout` here because there is nothing to time out — SMS auto retrieval is Android only, and the underlying `verifyPhoneNumber(_:uiDelegate:multiFactorSession:)` has no timeout parameter.
+
+#### JS
+
+```kotlin
+class JsPhoneVerificationProvider(
+    override val verifier: ApplicationVerifier,
+    private val code: CompletableDeferred<String>,
+) : PhoneVerificationProvider {
+    override suspend fun getVerificationCode(verificationId: String): String = code.await()
+}
+```
+
+`verifier` is an `ApplicationVerifier`, declared here as an external interface of `type` and `verify()`. This SDK does not supply an implementation, so pass the Firebase JS SDK's `RecaptchaVerifier`, which implements it. Note that JS is the one platform whose `getVerificationCode` receives the `verificationId`.
+
+#### JVM
+
+Phone authentication is not available on the JVM target. The [Firebase Java SDK](https://github.com/GitLiveApp/firebase-java-sdk) that backs it does not implement `PhoneAuthProvider`, so calling `verifyPhoneNumber` throws `NotImplementedError`.
+
+### Driving the flow yourself
+
+If you would rather not implement `PhoneVerificationProvider` at all, `PhoneAuthProvider.credential(verificationId, smsCode)` builds the credential directly from a verification id you obtained through the underlying official SDK.


### PR DESCRIPTION
Follows up #677, covering the half of it that the merged fix does not.

## Problem

#677 has two halves. The Android half — `getVerificationCode()` only ever being called from `onCodeAutoRetrievalTimeOut`, so whatever it returned when the auto retrieval window expired is what got submitted — was fixed on master in e8622c9 and is not yet released. The reporter's diagnosis of that was exactly right.

The second half is still open, and is a documentation problem rather than a bug:

> The iOS interface of `PhoneVerificationProvider` doesn't make any sense to me and I have no clue how to use it. This interface does not include a timeout. You also have to specific a `FIRAuthUIDelegateProtocol` and I have no idea what that is or where to get one.

There is nowhere to look this up. `firebase-auth/documentation.md` carries only the one line module description, the README has no phone auth section, and the common declaration is:

```kotlin
public expect interface PhoneVerificationProvider
```

No members at all — so neither the IDE nor the published API docs tell you what you have to implement. And what you have to implement differs on every platform, none of it derivable from common code:

|  | Android / JVM | Apple | JS |
|---|---|---|---|
| `activity`, `timeout`, `unit`, `codeSent` | yes | — | — |
| `delegate: FIRAuthUIDelegateProtocol?` | — | yes | — |
| `verifier: ApplicationVerifier` | — | — | yes |
| `getVerificationCode` | `()` | `()` | `(verificationId)` |

The issue has been open since November 2024 with follow-ups asking for help and no answer on the Apple half.

## Fix

Adds a phone authentication section to `firebase-auth/documentation.md`, which Dokka already picks up via `includes.setFrom("documentation.md")`. It covers the flow, an implementation example per platform, and the two specific things the reporter got stuck on:

- **`delegate` is nullable, and `null` is the normal choice.** Firebase falls back to `AuthDefaultUIDelegate.defaultUIDelegate()` when it is nil (`AuthURLPresenter.swift`), presenting from the app's own key window. You supply one only to control which view controller presents the `SFSafariViewController` used for reCAPTCHA, which iOS reaches only when silent APNs verification fails.
- **There is no `timeout` on Apple because there is nothing to time out.** SMS auto retrieval is Android only, and `verifyPhoneNumber(_:uiDelegate:multiFactorSession:)` has no timeout parameter.

It also documents two things that are easy to get wrong:

- the auto retrieval race introduced by e8622c9 — `getVerificationCode` may be cancelled while it is still suspended on the user, so a code entry screen has to tolerate that;
- that `timeout`/`unit` bound the auto retrieval window and not how long the user has to type.

## On the JVM target

`jvmMain` still has the pre-e8622c9 wiring, where `getVerificationCode()` is called only from `onCodeAutoRetrievalTimeOut`. I checked whether it was worth porting the fix across and concluded it is not: every method of `PhoneAuthProvider` in [firebase-java-sdk](https://github.com/GitLiveApp/firebase-java-sdk/blob/master/src/main/java/com/google/firebase/auth/PhoneAuthProvider.java) throws `NotImplementedError`, so none of those callbacks can ever fire. The code is unreachable rather than wrong, so I left it alone and documented that phone auth is unavailable on JVM instead. Happy to send a separate PR if you would rather keep the two source sets in sync anyway.

## Verification

The behavioural claims are checked against source, not recalled:

- pre-fix Android behaviour read from `e8622c99^:firebase-auth/src/androidMain/.../credentials.kt`
- `uiDelegate ?? AuthDefaultUIDelegate.defaultUIDelegate()` in firebase-ios-sdk `AuthURLPresenter.swift`
- the Apple signature `verifyPhoneNumber(_:uiDelegate:multiFactorSession:)` in firebase-ios-sdk `PhoneAuthProvider.swift`
- silent APNs with reCAPTCHA fallback per the Firebase iOS phone auth guide
- `RecaptchaVerifier implements ApplicationVerifierInternal` in firebase-js-sdk
- the per platform member lists read from each `actual interface` in this repo

One thing I could **not** verify, and so did not document: the meaning of `setTimeout(0, …)`, which the workaround posted on the thread relies on. Firebase Android auth is closed source and neither the reference nor the guide documents it.

## Scope

Documentation only — no code and no API change, so no `apiDump` needed.

I did not add KDoc to the declarations, despite the contributing guide asking for it on public API, because `expect interface PhoneVerificationProvider` has no members to attach it to and the useful content is inherently platform specific — it would have to be duplicated across four source sets to be visible. The module include gives it one home. Glad to add per-platform KDoc as well if you would prefer that.
